### PR TITLE
Add the BoxerToken model to Boxer Validator project

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -244,6 +244,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.86"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
+
+[[package]]
 name = "async-trait"
 version = "0.1.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -307,10 +313,12 @@ name = "boxer-validator-nginx"
 version = "0.0.0"
 dependencies = [
  "actix-web",
+ "anyhow",
  "async-trait",
  "futures-util",
  "jwt",
  "opentelemetry-datadog",
+ "rstest",
  "tokio",
 ]
 
@@ -504,12 +512,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -528,6 +552,12 @@ dependencies = [
  "futures-task",
  "futures-util",
 ]
+
+[[package]]
+name = "futures-io"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
 
 [[package]]
 name = "futures-macro"
@@ -553,15 +583,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
 
 [[package]]
+name = "futures-timer"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
+
+[[package]]
 name = "futures-util"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
  "futures-macro",
  "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "pin-utils",
  "slab",
@@ -1009,6 +1048,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-crate"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecf48c7ca261d60b74ab1a7b20da18bede46776b2e55535cb958eb595c5fa7b"
+dependencies = [
+ "toml_edit",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1101,6 +1149,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
+name = "relative-path"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
+
+[[package]]
 name = "rmp"
 version = "0.8.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1109,6 +1163,36 @@ dependencies = [
  "byteorder",
  "num-traits",
  "paste",
+]
+
+[[package]]
+name = "rstest"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b423f0e62bdd61734b67cd21ff50871dfaeb9cc74f869dcd6af974fbcb19936"
+dependencies = [
+ "futures",
+ "futures-timer",
+ "rstest_macros",
+ "rustc_version",
+]
+
+[[package]]
+name = "rstest_macros"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5e1711e7d14f74b12a58411c542185ef7fb7f2e7f8ee6e2940a883628522b42"
+dependencies = [
+ "cfg-if",
+ "glob",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "relative-path",
+ "rustc_version",
+ "syn",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -1376,6 +1460,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+
+[[package]]
+name = "toml_edit"
+version = "0.22.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "583c44c02ad26b0c3f3066fe629275e50627026c51ac2e595cca4c230ce1ce1d"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "winnow",
+]
+
+[[package]]
 name = "tracing"
 version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1572,6 +1673,15 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "0.6.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68a9bda4691f099d435ad181000724da8e5899daa10713c2d432552b9ccd3a6f"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "zerocopy"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,7 @@ futures-util = "0.3.8"
 jwt = "0.16.0"
 opentelemetry-datadog = "0.12.0"
 async-trait = "0.1.81"
+anyhow = "1.0.86"
+
+[dev-dependencies]
+rstest = "0.22.0"

--- a/src/http/conversions.rs
+++ b/src/http/conversions.rs
@@ -1,6 +1,6 @@
+use crate::models::token::BoxerToken;
 use actix_web::http::header::HeaderValue;
 use anyhow::bail;
-use crate::models::token::BoxerToken;
 
 impl TryFrom<&HeaderValue> for BoxerToken {
     type Error = anyhow::Error;

--- a/src/http/conversions.rs
+++ b/src/http/conversions.rs
@@ -1,0 +1,58 @@
+use actix_web::http::header::HeaderValue;
+use anyhow::bail;
+use crate::models::token::BoxerToken;
+
+impl TryFrom<&HeaderValue> for BoxerToken {
+    type Error = anyhow::Error;
+
+    // Compiler will complain that `return Err` statements in this code are unreachable,
+    // but this is not true. See test cases below.
+    #[allow(unreachable_code)]
+    fn try_from(value: &HeaderValue) -> Result<Self, Self::Error> {
+        match value.to_str() {
+            Ok(string_value) => {
+                let tokens = string_value.split(" ").collect::<Vec<&str>>();
+
+                if tokens.len() != 2 {
+                    return Err(bail!("Invalid token format"));
+                }
+
+                if tokens[0] != "Bearer" {
+                    return Err(bail!("Invalid token format"));
+                }
+
+                Ok(BoxerToken::from(tokens[1].to_owned()))
+            }
+            Err(_) => bail!("Invalid token format"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rstest::rstest;
+
+    #[rstest]
+    fn test_parsing_valid_token() {
+        let header = HeaderValue::from_static("Bearer token");
+        let token = BoxerToken::try_from(&header).unwrap();
+        let string_token: String = token.into();
+        assert_eq!(string_token, "token".to_string());
+    }
+
+    #[rstest]
+    #[case("token")]
+    #[case("My token")]
+    #[case("My suer cool token")]
+    #[case("")]
+    #[case("Bearer")]
+    fn test_parsing_invalid_token(#[case] token: &str) {
+        let header = HeaderValue::from_str(token).unwrap();
+        let token = BoxerToken::try_from(&header);
+        assert_eq!(
+            token.is_err_and(|e| e.to_string() == "Invalid token format"),
+            true
+        );
+    }
+}

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -1,2 +1,2 @@
+pub mod conversions;
 pub mod urls;
-pub  mod conversions;

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -1,1 +1,2 @@
 pub mod urls;
+pub  mod conversions;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 mod http;
+mod models;
 
 use crate::http::urls::token_review;
 use actix_web::{App, HttpServer};

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -1,0 +1,1 @@
+pub mod token;

--- a/src/models/token.rs
+++ b/src/models/token.rs
@@ -1,0 +1,18 @@
+/// Represents an external JWT Token used to authorize the `ExternalIdentity` and issue an `InternalToken`
+pub struct BoxerToken {
+    pub token: String,
+}
+
+/// Allows `ExternalToken` to be converted to a String
+impl Into<String> for BoxerToken {
+    fn into(self) -> String {
+        self.token.clone()
+    }
+}
+
+/// Allows a String to be converted to an `ExternalToken`
+impl From<String> for BoxerToken {
+    fn from(token: String) -> Self {
+        BoxerToken { token }
+    }
+}


### PR DESCRIPTION
## Scope

This pull request introduces the BoxerToken model used in the boxer-validator nginx to extract the token from Authorization Header.


## Checklist

- [ ] GitHub issue exists for this change.
- [x] Unit tests added and they pass.
- [x] Line Coverage is at least 80%.
- [ ] Review requested on `latest` commit.