### PR TITLE
Add kubernetes backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,6 +558,7 @@ dependencies = [
 [[package]]
 name = "boxer_core"
 version = "0.1.0"
+source = "git+https://github.com/SneaksAndData/boxer-core.git#80443c17e04948c226f11fee7384c71d202bef41"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,6 +558,7 @@ dependencies = [
 [[package]]
 name = "boxer_core"
 version = "0.1.0"
+source = "git+https://github.com/SneaksAndData/boxer-core.git#648857796a7e4b0d612c82c676187935f5399532"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -208,15 +208,15 @@ checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
 name = "ahash"
-version = "0.8.11"
+version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
- "getrandom 0.2.15",
+ "getrandom 0.3.3",
  "once_cell",
  "version_check",
- "zerocopy 0.7.35",
+ "zerocopy",
 ]
 
 [[package]]
@@ -538,10 +538,12 @@ version = "0.0.0"
 dependencies = [
  "actix-web",
  "anyhow",
+ "async-trait",
  "base64 0.22.1",
  "boxer_core",
  "cedar-policy",
  "config",
+ "duration-string",
  "env_logger",
  "flate2",
  "futures-util",
@@ -556,7 +558,6 @@ dependencies = [
 [[package]]
 name = "boxer_core"
 version = "0.1.0"
-source = "git+https://github.com/SneaksAndData/boxer-core.git#40ea01968d7a3131fdeacbf989ba013621b203d8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -569,6 +570,7 @@ dependencies = [
  "maplit",
  "serde",
  "serde_json",
+ "serde_yml",
  "tokio",
  "uuid",
 ]
@@ -952,6 +954,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "442039f5147480ba31067cb00ada1adae6892028e40e45fc5de7b7df6dcc1b5f"
 dependencies = [
  "const-random",
+]
+
+[[package]]
+name = "duration-string"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04782251e09dc67c90d694d89e9a3e5fc6cfe883df1b203202de672d812fb299"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -2079,6 +2090,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
+name = "libyml"
+version = "0.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3302702afa434ffa30847a83305f0a69d6abd74293b6554c18ec85c7ef30c980"
+dependencies = [
+ "anyhow",
+ "version_check",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2583,7 +2604,7 @@ version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
- "zerocopy 0.8.26",
+ "zerocopy",
 ]
 
 [[package]]
@@ -3234,6 +3255,21 @@ dependencies = [
  "ryu",
  "serde",
  "unsafe-libyaml",
+]
+
+[[package]]
+name = "serde_yml"
+version = "0.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59e2dd588bf1597a252c3b920e0143eb99b0f76e4e082f4c92ce34fbc9e71ddd"
+dependencies = [
+ "indexmap 2.10.0",
+ "itoa",
+ "libyml",
+ "memchr",
+ "ryu",
+ "serde",
+ "version_check",
 ]
 
 [[package]]
@@ -4314,31 +4350,11 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.7.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
-dependencies = [
- "zerocopy-derive 0.7.35",
-]
-
-[[package]]
-name = "zerocopy"
 version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f"
 dependencies = [
- "zerocopy-derive 0.8.26",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.7.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "zerocopy-derive",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,7 +558,6 @@ dependencies = [
 [[package]]
 name = "boxer_core"
 version = "0.1.0"
-source = "git+https://github.com/SneaksAndData/boxer-core.git#80443c17e04948c226f11fee7384c71d202bef41"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,8 @@ log = "0.4.22"
 env_logger = "0.11.5"
 flate2 = "1.0"
 base64 = "0.22.1"
-boxer_core = { git = "https://github.com/SneaksAndData/boxer-core.git" }
-#boxer_core = { path = "../boxer-core/" } # This line is for development, to be removed in the future,
+#boxer_core = { git = "https://github.com/SneaksAndData/boxer-core.git" }
+boxer_core = { path = "../boxer-core/" } # This line is for development, to be removed in the future,
 # before moving to production
 serde_json = "1.0.140"
 utoipa = { version = "5.3.1", features = ["actix_extras"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,13 +11,17 @@ log = "0.4.22"
 env_logger = "0.11.5"
 flate2 = "1.0"
 base64 = "0.22.1"
-boxer_core = { git = "https://github.com/SneaksAndData/boxer-core.git" }
+#boxer_core = { git = "https://github.com/SneaksAndData/boxer-core.git" }
+boxer_core = { path = "../boxer-core/" } # This line is for development, to be removed in the future,
+# before moving to production
 serde_json = "1.0.140"
 utoipa = { version = "5.3.1", features = ["actix_extras"] }
 actix-web = "4.9.0"
 cedar-policy = "4.4.0"
 config = "0.15.11"
 serde = { version = "1.0.207", features = ["derive"] }
+async-trait = "0.1.88"
+duration-string = { version = "0.5.2", features = ["serde"] }
 
 [dev-dependencies]
 rstest = "0.25.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,8 @@ log = "0.4.22"
 env_logger = "0.11.5"
 flate2 = "1.0"
 base64 = "0.22.1"
-#boxer_core = { git = "https://github.com/SneaksAndData/boxer-core.git" }
-boxer_core = { path = "../boxer-core/" } # This line is for development, to be removed in the future,
+boxer_core = { git = "https://github.com/SneaksAndData/boxer-core.git" }
+#boxer_core = { path = "../boxer-core/" } # This line is for development, to be removed in the future,
 # before moving to production
 serde_json = "1.0.140"
 utoipa = { version = "5.3.1", features = ["actix_extras"] }

--- a/settings.toml
+++ b/settings.toml
@@ -14,3 +14,4 @@ lease_renew_duration = "15s"             # Duration string for lease renewal int
 [backend.kubernetes.schema_repository]
 label_selector_key = "app.kubernetes.io/component"
 label_selector_value = "validator-schema"
+name = "boxer-validator-schema"

--- a/settings.toml
+++ b/settings.toml
@@ -1,2 +1,16 @@
 # Application settings
 instance_name = "integration-tests"
+
+[backend]
+# Kubernetes backend settings
+[backend.kubernetes]
+exec = "kind get kubeconfig --name kind" # Command to get kubeconfig for the Kind cluster
+namespace = "default"                    # Kubernetes namespace
+lease_name = "boxer-validator"           # Name for the lease object
+lease_duration = "60s"                   # Duration string for lease lifetime
+lease_renew_duration = "15s"             # Duration string for lease renewal interval
+
+# Repository settings for schemas
+[backend.kubernetes.schema_repository]
+label_selector_key = "app.kubernetes.io/component"
+label_selector_value = "validator-schema"

--- a/src/http/controllers/token_review.rs
+++ b/src/http/controllers/token_review.rs
@@ -6,15 +6,16 @@ use actix_web::http::StatusCode;
 use actix_web::web::Data;
 use actix_web::{get, HttpResponse};
 use log::debug;
+use std::sync::Arc;
 
 #[utoipa::path(context_path = "/token/review", responses((status = OK)))]
 #[get("/token/review")]
 async fn get(
     boxer_claims: BoxerClaims,
     request_context: RequestContext,
-    cedar_validation_service: Data<Box<CedarValidationService>>,
+    cedar_validation_service: Data<Arc<CedarValidationService>>,
 ) -> HttpResponse {
-    let status_code = match cedar_validation_service.validate(boxer_claims, request_context) {
+    let status_code = match cedar_validation_service.validate(boxer_claims, request_context).await {
         Ok(_) => {
             debug!("Token validated successfully");
             StatusCode::OK

--- a/src/http/filters/jwt_filter.rs
+++ b/src/http/filters/jwt_filter.rs
@@ -43,8 +43,6 @@ where
             let mut validation = Validation::new();
             validation.iss = Some(settings.valid_issuers.clone());
             validation.aud = Some(settings.valid_audiences.clone());
-            validation.validate_signature = false;
-            validation.validate_exp = false;
 
             // It's OK to unwrap here because we should panic if cannot build the authorizer
             let authorizer: Authorizer<DynamicClaimsCollection> = JwtAuthorizer::from_secret(settings.secret)

--- a/src/http/filters/jwt_filter.rs
+++ b/src/http/filters/jwt_filter.rs
@@ -43,6 +43,8 @@ where
             let mut validation = Validation::new();
             validation.iss = Some(settings.valid_issuers.clone());
             validation.aud = Some(settings.valid_audiences.clone());
+            validation.validate_signature = false;
+            validation.validate_exp = false;
 
             // It's OK to unwrap here because we should panic if cannot build the authorizer
             let authorizer: Authorizer<DynamicClaimsCollection> = JwtAuthorizer::from_secret(settings.secret)

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,7 +31,8 @@ async fn main() -> Result<()> {
     let current_backend = backends::new()
         .configure(&cm.backend.kubernetes, cm.instance_name.clone())
         .await?;
-    let schema_provider = Arc::new(KubernetesSchemaProvider::new(current_backend.get_schemas_repository()));
+    
+    let schema_provider = Arc::new(KubernetesSchemaProvider::new(current_backend.get_schemas_repository(), cm.backend.kubernetes.schema_repository.name));
     let cedar_validation_service = Arc::new(CedarValidationService::new(schema_provider));
 
     HttpServer::new(move || {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+use boxer_core::services::backends::SchemaRepositorySource;
 mod http;
 mod models;
 mod services;
@@ -5,11 +6,15 @@ mod services;
 use crate::http::controllers::schema;
 use crate::http::controllers::token_review;
 use crate::http::filters::jwt_filter::InternalTokenMiddlewareFactory;
+use crate::services::backends;
 use crate::services::cedar_validation_service::CedarValidationService;
 use crate::services::configuration::models::AppSettings;
+use crate::services::schema_provider::KubernetesSchemaProvider;
 use actix_web::{web, App, HttpServer};
 use anyhow::Result;
+use boxer_core::services::backends::BackendConfiguration;
 use log::info;
+use std::sync::Arc;
 
 #[actix_web::main]
 async fn main() -> Result<()> {
@@ -22,9 +27,14 @@ async fn main() -> Result<()> {
     info!("Instance name {}", cm.instance_name);
 
     println!("listening on {}:{}", &addr.0, &addr.1);
+
+    let current_backend = backends::new().configure(&cm.backend.kubernetes, cm.instance_name.clone()).await?;
+    let schema_provider = Arc::new(KubernetesSchemaProvider::new(current_backend.get_schemas_repository()));
+    let cedar_validation_service = Arc::new(CedarValidationService::new(schema_provider));
+
     HttpServer::new(move || {
         App::new()
-            .app_data(web::Data::new(Box::new(CedarValidationService::new())))
+            .app_data(web::Data::new(cedar_validation_service.clone()))
             // The last middleware in the chain should always be InternalTokenMiddleware
             // to ensure that the token is valid in the beginning of the request processing
             .wrap(InternalTokenMiddlewareFactory::new())

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,7 +28,9 @@ async fn main() -> Result<()> {
 
     println!("listening on {}:{}", &addr.0, &addr.1);
 
-    let current_backend = backends::new().configure(&cm.backend.kubernetes, cm.instance_name.clone()).await?;
+    let current_backend = backends::new()
+        .configure(&cm.backend.kubernetes, cm.instance_name.clone())
+        .await?;
     let schema_provider = Arc::new(KubernetesSchemaProvider::new(current_backend.get_schemas_repository()));
     let cedar_validation_service = Arc::new(CedarValidationService::new(schema_provider));
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,8 +31,11 @@ async fn main() -> Result<()> {
     let current_backend = backends::new()
         .configure(&cm.backend.kubernetes, cm.instance_name.clone())
         .await?;
-    
-    let schema_provider = Arc::new(KubernetesSchemaProvider::new(current_backend.get_schemas_repository(), cm.backend.kubernetes.schema_repository.name));
+
+    let schema_provider = Arc::new(KubernetesSchemaProvider::new(
+        current_backend.get_schemas_repository(),
+        cm.backend.kubernetes.schema_repository.name,
+    ));
     let cedar_validation_service = Arc::new(CedarValidationService::new(schema_provider));
 
     HttpServer::new(move || {

--- a/src/models/boxer_claims/v1/boxer_claims.rs
+++ b/src/models/boxer_claims/v1/boxer_claims.rs
@@ -44,7 +44,7 @@ impl TryFrom<&DynamicClaimsCollection> for BoxerClaims {
 
     fn try_from(c: &DynamicClaimsCollection) -> Result<Self, Self::Error> {
         let api_version = get_claim(c, API_VERSION_KEY).ok_or(anyhow::anyhow!("Missing api version"))?;
-        // let policy = get_claim(c, POLICY_KEY).ok_or(anyhow::anyhow!("Missing policy"))?;
+        let policy = get_claim(c, POLICY_KEY).ok_or(anyhow::anyhow!("Missing policy"))?;
         let user_id = get_claim(c, USER_ID_KEY).ok_or(anyhow::anyhow!("Missing user id"))?;
         let identity_provider =
             get_claim(c, IDENTITY_PROVIDER_KEY).ok_or(anyhow::anyhow!("Missing identity provider"))?;
@@ -52,7 +52,7 @@ impl TryFrom<&DynamicClaimsCollection> for BoxerClaims {
 
         Ok(BoxerClaims {
             api_version: api_version.to_string(),
-            policy: "".to_owned(),
+            policy: policy.to_string(),
             user_id: user_id.to_string(),
             identity_provider: identity_provider.to_string(),
             schema: String::from_utf8(STANDARD.decode(&schema)?)?,

--- a/src/models/boxer_claims/v1/boxer_claims.rs
+++ b/src/models/boxer_claims/v1/boxer_claims.rs
@@ -13,6 +13,7 @@ const API_VERSION_KEY: &str = "boxer.sneaksanddata.com/api-version";
 const POLICY_KEY: &str = "boxer.sneaksanddata.com/policy";
 const USER_ID_KEY: &str = "boxer.sneaksanddata.com/user-id";
 const IDENTITY_PROVIDER_KEY: &str = "boxer.sneaksanddata.com/identity-provider";
+const SCHEMA_KEY: &str = "boxer.sneaksanddata.com/schema";
 
 #[derive(Debug)]
 #[allow(dead_code)]
@@ -21,6 +22,7 @@ pub struct BoxerClaims {
     pub policy: String,
     pub user_id: String,
     pub identity_provider: String,
+    pub schema: String,
 }
 
 impl BoxerClaims {
@@ -42,16 +44,18 @@ impl TryFrom<&DynamicClaimsCollection> for BoxerClaims {
 
     fn try_from(c: &DynamicClaimsCollection) -> Result<Self, Self::Error> {
         let api_version = get_claim(c, API_VERSION_KEY).ok_or(anyhow::anyhow!("Missing api version"))?;
-        let policy = get_claim(c, POLICY_KEY).ok_or(anyhow::anyhow!("Missing policy"))?;
+        // let policy = get_claim(c, POLICY_KEY).ok_or(anyhow::anyhow!("Missing policy"))?;
         let user_id = get_claim(c, USER_ID_KEY).ok_or(anyhow::anyhow!("Missing user id"))?;
         let identity_provider =
             get_claim(c, IDENTITY_PROVIDER_KEY).ok_or(anyhow::anyhow!("Missing identity provider"))?;
+        let schema = get_claim(c, SCHEMA_KEY).ok_or(anyhow::anyhow!("Missing schema"))?;
 
         Ok(BoxerClaims {
             api_version: api_version.to_string(),
-            policy: policy.to_string(),
+            policy: "".to_owned(),
             user_id: user_id.to_string(),
             identity_provider: identity_provider.to_string(),
+            schema: String::from_utf8(STANDARD.decode(&schema)?)?,
         })
     }
 }

--- a/src/services/backends.rs
+++ b/src/services/backends.rs
@@ -1,0 +1,51 @@
+use crate::services::configuration::models::KubernetesBackendSettings;
+use anyhow::bail;
+use async_trait::async_trait;
+use boxer_core::services::backends::kubernetes::kubeconfig_loader::{from_command, from_file};
+use boxer_core::services::backends::kubernetes::kubernetes_resource_manager::KubernetesResourceManagerConfig;
+use boxer_core::services::backends::kubernetes::repositories::schema_repository::KubernetesSchemaRepository;
+use boxer_core::services::backends::{BackendConfiguration};
+use std::sync::Arc;
+use crate::services::backends::kubernetes::KubernetesBackend;
+
+mod kubernetes;
+
+pub struct BackendBuilder;
+pub fn new() -> BackendBuilder {
+    BackendBuilder
+}
+
+#[async_trait]
+impl BackendConfiguration for BackendBuilder {
+    type BackendSettings = KubernetesBackendSettings;
+    type InitializedBackend = KubernetesBackend;
+
+    async fn configure(
+        self,
+        settings: &Self::BackendSettings,
+        instance_name: String,
+    ) -> anyhow::Result<Arc<Self::InitializedBackend>> {
+        let kubeconfig = match settings {
+            KubernetesBackendSettings { kubeconfig: Some(path), .. } => from_file().load(&path).await?,
+            KubernetesBackendSettings { exec: Some(command), .. } => from_command().load(&command).await?,
+            KubernetesBackendSettings { kubeconfig: None, exec: None, .. } => { bail!("Kubernetes backend configuration is missing") }
+        };
+
+        let repository_config = KubernetesResourceManagerConfig {
+            namespace: settings.namespace.clone(),
+            label_selector_key: settings.schema_repository.label_selector_key.clone(),
+            label_selector_value: settings.schema_repository.label_selector_value.clone(),
+            lease_name: settings.lease_name.clone(),
+            lease_duration: settings.lease_duration.into(),
+            renew_deadline: settings.lease_renew_duration.into(),
+            claimant: instance_name,
+            kubeconfig,
+        };
+
+        let schema_repository = KubernetesSchemaRepository::start(repository_config).await?;
+
+        Ok(Arc::new(kubernetes::KubernetesBackend {
+            schema_repository: Arc::new(schema_repository),
+        }))
+    }
+}

--- a/src/services/backends.rs
+++ b/src/services/backends.rs
@@ -1,12 +1,12 @@
+use crate::services::backends::kubernetes::KubernetesBackend;
 use crate::services::configuration::models::KubernetesBackendSettings;
 use anyhow::bail;
 use async_trait::async_trait;
 use boxer_core::services::backends::kubernetes::kubeconfig_loader::{from_command, from_file};
 use boxer_core::services::backends::kubernetes::kubernetes_resource_manager::KubernetesResourceManagerConfig;
 use boxer_core::services::backends::kubernetes::repositories::schema_repository::KubernetesSchemaRepository;
-use boxer_core::services::backends::{BackendConfiguration};
+use boxer_core::services::backends::BackendConfiguration;
 use std::sync::Arc;
-use crate::services::backends::kubernetes::KubernetesBackend;
 
 mod kubernetes;
 
@@ -26,9 +26,19 @@ impl BackendConfiguration for BackendBuilder {
         instance_name: String,
     ) -> anyhow::Result<Arc<Self::InitializedBackend>> {
         let kubeconfig = match settings {
-            KubernetesBackendSettings { kubeconfig: Some(path), .. } => from_file().load(&path).await?,
-            KubernetesBackendSettings { exec: Some(command), .. } => from_command().load(&command).await?,
-            KubernetesBackendSettings { kubeconfig: None, exec: None, .. } => { bail!("Kubernetes backend configuration is missing") }
+            KubernetesBackendSettings {
+                kubeconfig: Some(path), ..
+            } => from_file().load(&path).await?,
+            KubernetesBackendSettings {
+                exec: Some(command), ..
+            } => from_command().load(&command).await?,
+            KubernetesBackendSettings {
+                kubeconfig: None,
+                exec: None,
+                ..
+            } => {
+                bail!("Kubernetes backend configuration is missing")
+            }
         };
 
         let repository_config = KubernetesResourceManagerConfig {

--- a/src/services/backends/kubernetes.rs
+++ b/src/services/backends/kubernetes.rs
@@ -1,0 +1,17 @@
+use boxer_core::services::backends::{Backend, SchemaRepositorySource};
+use boxer_core::services::base::types::SchemaRepository;
+use std::sync::Arc;
+
+pub struct KubernetesBackend {
+    pub schema_repository: Arc<SchemaRepository>,
+}
+
+impl SchemaRepositorySource for KubernetesBackend {
+    fn get_schemas_repository(&self) -> Arc<SchemaRepository> {
+        self.schema_repository.clone()
+    }
+}
+
+impl Backend for KubernetesBackend {
+    // This is marker trait, so no methods are required here
+}

--- a/src/services/base/mod.rs
+++ b/src/services/base/mod.rs
@@ -1,1 +1,2 @@
+pub mod schema_provider;
 pub mod validation_service;

--- a/src/services/base/schema_provider.rs
+++ b/src/services/base/schema_provider.rs
@@ -1,0 +1,10 @@
+use crate::models::boxer_claims::v1::boxer_claims::BoxerClaims;
+use anyhow::Result;
+use async_trait::async_trait;
+use cedar_policy::Schema;
+
+#[async_trait]
+pub trait SchemaProvider: Send + Sync {
+    #[allow(dead_code)]
+    async fn get_schema(&self, boxer_claims: &BoxerClaims) -> Result<Schema>;
+}

--- a/src/services/base/validation_service.rs
+++ b/src/services/base/validation_service.rs
@@ -1,6 +1,8 @@
 use crate::models::boxer_claims::v1::boxer_claims::BoxerClaims;
 use crate::models::request_context::RequestContext;
+use async_trait::async_trait;
 
+#[async_trait]
 pub trait ValidationService {
-    fn validate(&self, boxer_claims: BoxerClaims, request_context: RequestContext) -> Result<(), anyhow::Error>;
+    async fn validate(&self, boxer_claims: BoxerClaims, request_context: RequestContext) -> Result<(), anyhow::Error>;
 }

--- a/src/services/cedar_validation_service.rs
+++ b/src/services/cedar_validation_service.rs
@@ -1,5 +1,6 @@
 use crate::models::boxer_claims::v1::boxer_claims::BoxerClaims;
 use crate::models::request_context::RequestContext;
+use crate::services::base::schema_provider::SchemaProvider;
 use crate::services::base::validation_service::ValidationService;
 use cedar_policy::{Authorizer, Context, Entities, EntityId, EntityTypeName, EntityUid, Request};
 use log::info;
@@ -8,12 +9,15 @@ use std::sync::Arc;
 
 pub struct CedarValidationService {
     authorizer: Authorizer,
+    #[allow(dead_code)]
+    schema_provider: Arc<dyn SchemaProvider>,
 }
 
 impl CedarValidationService {
-    pub fn new() -> Self {
+    pub fn new(schema_provider: Arc<dyn SchemaProvider>) -> Self {
         CedarValidationService {
             authorizer: Authorizer::new(),
+            schema_provider,
         }
     }
 }

--- a/src/services/configuration/models.rs
+++ b/src/services/configuration/models.rs
@@ -5,7 +5,7 @@ use serde::Deserialize;
 pub struct SchemaRepositorySettings {
     pub label_selector_key: String,
     pub label_selector_value: String,
-    pub name: String
+    pub name: String,
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/services/configuration/models.rs
+++ b/src/services/configuration/models.rs
@@ -1,6 +1,32 @@
+use duration_string::DurationString;
 use serde::Deserialize;
+
+#[derive(Debug, Deserialize)]
+pub struct RepositorySettings {
+    pub label_selector_key: String,
+    pub label_selector_value: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct KubernetesBackendSettings {
+    pub kubeconfig: Option<String>,
+    pub exec: Option<String>,
+    pub namespace: String,
+
+    pub lease_name: String,
+    pub lease_duration: DurationString,
+    pub lease_renew_duration: DurationString,
+
+    pub schema_repository: RepositorySettings,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct BackendSettings {
+    pub kubernetes: KubernetesBackendSettings,
+}
 
 #[derive(Debug, Deserialize)]
 pub struct AppSettings {
     pub instance_name: String,
+    pub backend: BackendSettings,
 }

--- a/src/services/configuration/models.rs
+++ b/src/services/configuration/models.rs
@@ -2,9 +2,10 @@ use duration_string::DurationString;
 use serde::Deserialize;
 
 #[derive(Debug, Deserialize)]
-pub struct RepositorySettings {
+pub struct SchemaRepositorySettings {
     pub label_selector_key: String,
     pub label_selector_value: String,
+    pub name: String
 }
 
 #[derive(Debug, Deserialize)]
@@ -17,7 +18,7 @@ pub struct KubernetesBackendSettings {
     pub lease_duration: DurationString,
     pub lease_renew_duration: DurationString,
 
-    pub schema_repository: RepositorySettings,
+    pub schema_repository: SchemaRepositorySettings,
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -1,3 +1,5 @@
+pub mod backends;
 pub mod base;
 pub mod cedar_validation_service;
 pub mod configuration;
+pub mod schema_provider;

--- a/src/services/schema_provider.rs
+++ b/src/services/schema_provider.rs
@@ -3,8 +3,10 @@ use crate::services::base::schema_provider::SchemaProvider;
 use anyhow::Result;
 use async_trait::async_trait;
 use boxer_core::services::base::types::SchemaRepository;
-use cedar_policy::Schema;
+use cedar_policy::{Schema, SchemaFragment};
 use std::sync::Arc;
+
+const SCHEMA_LOCATION: &str = "boxer-validator-schema";
 
 pub struct KubernetesSchemaProvider {
     #[allow(dead_code)]
@@ -13,10 +15,10 @@ pub struct KubernetesSchemaProvider {
 
 #[async_trait]
 impl SchemaProvider for KubernetesSchemaProvider {
-    async fn get_schema(&self, _boxer_claims: &BoxerClaims) -> Result<Schema> {
-        // Here you would implement the logic to retrieve the schema based on the boxer_claims.
-        // For demonstration purposes, we return a dummy schema.
-        Schema::from_json_str("").map_err(|e| e.into())
+    async fn get_schema(&self, boxer_claims: &BoxerClaims) -> Result<Schema> {
+        let actions_schema = self.schema_repository.get(SCHEMA_LOCATION.to_string()).await?;
+        let principal_schema = SchemaFragment::from_json_str(&boxer_claims.schema)?;
+        Schema::from_schema_fragments(vec![actions_schema, principal_schema]).map_err(anyhow::Error::from)
     }
 }
 

--- a/src/services/schema_provider.rs
+++ b/src/services/schema_provider.rs
@@ -1,0 +1,27 @@
+use crate::models::boxer_claims::v1::boxer_claims::BoxerClaims;
+use crate::services::base::schema_provider::SchemaProvider;
+use anyhow::Result;
+use async_trait::async_trait;
+use boxer_core::services::base::types::SchemaRepository;
+use cedar_policy::Schema;
+use std::sync::Arc;
+
+pub struct KubernetesSchemaProvider {
+    #[allow(dead_code)]
+    schema_repository: Arc<SchemaRepository>,
+}
+
+#[async_trait]
+impl SchemaProvider for KubernetesSchemaProvider {
+    async fn get_schema(&self, _boxer_claims: &BoxerClaims) -> Result<Schema> {
+        // Here you would implement the logic to retrieve the schema based on the boxer_claims.
+        // For demonstration purposes, we return a dummy schema.
+        Schema::from_json_str("").map_err(|e| e.into())
+    }
+}
+
+impl KubernetesSchemaProvider {
+    pub fn new(schema_repository: Arc<SchemaRepository>) -> Self {
+        KubernetesSchemaProvider { schema_repository }
+    }
+}

--- a/src/services/schema_provider.rs
+++ b/src/services/schema_provider.rs
@@ -22,6 +22,9 @@ impl SchemaProvider for KubernetesSchemaProvider {
 
 impl KubernetesSchemaProvider {
     pub fn new(schema_repository: Arc<SchemaRepository>, schema_name: String) -> Self {
-        KubernetesSchemaProvider { schema_repository, schema_name }
+        KubernetesSchemaProvider {
+            schema_repository,
+            schema_name,
+        }
     }
 }

--- a/src/services/schema_provider.rs
+++ b/src/services/schema_provider.rs
@@ -6,24 +6,22 @@ use boxer_core::services::base::types::SchemaRepository;
 use cedar_policy::{Schema, SchemaFragment};
 use std::sync::Arc;
 
-const SCHEMA_LOCATION: &str = "boxer-validator-schema";
-
 pub struct KubernetesSchemaProvider {
-    #[allow(dead_code)]
     schema_repository: Arc<SchemaRepository>,
+    schema_name: String,
 }
 
 #[async_trait]
 impl SchemaProvider for KubernetesSchemaProvider {
     async fn get_schema(&self, boxer_claims: &BoxerClaims) -> Result<Schema> {
-        let actions_schema = self.schema_repository.get(SCHEMA_LOCATION.to_string()).await?;
+        let actions_schema = self.schema_repository.get(self.schema_name.clone()).await?;
         let principal_schema = SchemaFragment::from_json_str(&boxer_claims.schema)?;
         Schema::from_schema_fragments(vec![actions_schema, principal_schema]).map_err(anyhow::Error::from)
     }
 }
 
 impl KubernetesSchemaProvider {
-    pub fn new(schema_repository: Arc<SchemaRepository>) -> Self {
-        KubernetesSchemaProvider { schema_repository }
+    pub fn new(schema_repository: Arc<SchemaRepository>, schema_name: String) -> Self {
+        KubernetesSchemaProvider { schema_repository, schema_name }
     }
 }


### PR DESCRIPTION
Resolves #39 

## Scope

Implemented:
- Kubernetes backend vor validation service
- `KubernetesSchemaProvider` class for merging schemas from request and storage.

Additional changes:
- Extended configuration
- `ValidationService.validate` is marked as async.
- Fixed incorrect data injection

## Checklist

- [ ] GitHub issue exists for this change.
- [ ] Unit tests added and they pass.
- [ ] Line Coverage is at least 80%.
- [ ] Review requested on `latest` commit.