### PR TITLE
Expose Action management API

### DIFF
--- a/src/http/controllers/action_set.rs
+++ b/src/http/controllers/action_set.rs
@@ -1,0 +1,45 @@
+pub mod models;
+
+use crate::http::controllers::action_set::models::ActionSetRegistration;
+use crate::http::errors::*;
+use crate::services::repositories::action_repository::ActionRepository;
+use actix_web::dev::HttpServiceFactory;
+use actix_web::web::{Data, Json, Path};
+use actix_web::{delete, get, post, web, HttpResponse, Responder};
+use log::error;
+use std::sync::Arc;
+
+#[utoipa::path(context_path = "/action_set/", responses((status = OK)), request_body = ActionSetRegistration)]
+#[post("{id}")]
+async fn post_action_set(
+    id: Path<String>,
+    request: Json<ActionSetRegistration>,
+    data: Data<Arc<ActionRepository>>,
+) -> Result<impl Responder> {
+    data.upsert(id.to_string(), request.into_inner()).await.map_err(|e| {
+        error!("Failed ot insert action_set: {:?}", e);
+        e
+    })?;
+    Ok(HttpResponse::Ok().finish())
+}
+
+#[utoipa::path(context_path = "/action_set/", responses((status = OK, body = ActionSetRegistration)))]
+#[get("{id}")]
+async fn get_action_set(id: Path<String>, data: Data<Arc<ActionRepository>>) -> Result<impl Responder> {
+    let action_set = data.get(id.to_string()).await?;
+    Ok(Json(action_set))
+}
+
+#[utoipa::path(context_path = "/action_set/", responses((status = OK)))]
+#[delete("{id}")]
+async fn delete_action_set(id: Path<String>, data: Data<Arc<ActionRepository>>) -> Result<impl Responder> {
+    data.delete(id.to_string()).await?;
+    Ok(HttpResponse::Ok().finish())
+}
+
+pub fn crud() -> impl HttpServiceFactory {
+    web::scope("/action_set")
+        .service(post_action_set)
+        .service(get_action_set)
+        .service(delete_action_set)
+}

--- a/src/http/controllers/action_set/models.rs
+++ b/src/http/controllers/action_set/models.rs
@@ -1,0 +1,19 @@
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+
+#[derive(ToSchema, Serialize, Deserialize)]
+#[schema(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase")]
+pub struct ActionRouteRegistration {
+    pub method: String,
+    pub route_template: String,
+    pub action_uid: String,
+}
+
+#[derive(ToSchema, Serialize, Deserialize)]
+#[schema(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase")]
+pub struct ActionSetRegistration {
+    pub hostname: String,
+    pub routes: Vec<ActionRouteRegistration>,
+}

--- a/src/http/controllers/mod.rs
+++ b/src/http/controllers/mod.rs
@@ -1,2 +1,3 @@
+pub mod action_set;
 pub mod schema;
 pub mod token_review;

--- a/src/http/openapi.rs
+++ b/src/http/openapi.rs
@@ -6,5 +6,8 @@ use utoipa::OpenApi;
     controllers::schema::get_schema,
     controllers::schema::post_schema,
     controllers::schema::delete_schema,
+    controllers::action_set::get_action_set,
+    controllers::action_set::post_action_set,
+    controllers::action_set::delete_action_set,
 ))]
 pub struct ApiDoc;

--- a/src/services/repositories/action_repository.rs
+++ b/src/services/repositories/action_repository.rs
@@ -4,7 +4,8 @@ pub mod read_write;
 #[cfg(test)]
 mod tests;
 
-use crate::services::repositories::action_repository::models::{ActionDiscoveryDocument, ActionDiscoveryDocumentSpec};
+use crate::http::controllers::action_set::models::ActionSetRegistration;
+use crate::services::repositories::action_repository::models::ActionDiscoveryDocument;
 use crate::services::repositories::models::RequestSegment;
 use boxer_core::services::backends::kubernetes::kubernetes_resource_watcher::ResourceUpdateHandler;
 use boxer_core::services::base::upsert_repository::{CanDelete, ReadOnlyRepository, UpsertRepository};
@@ -17,9 +18,9 @@ pub trait ActionReadOnlyRepositoryInterface:
 }
 
 pub trait ActionRepositoryInterface:
-    ReadOnlyRepository<String, ActionDiscoveryDocumentSpec, ReadError = anyhow::Error>
-    + UpsertRepository<String, ActionDiscoveryDocumentSpec, Error = anyhow::Error>
-    + CanDelete<String, ActionDiscoveryDocumentSpec, DeleteError = anyhow::Error>
+    ReadOnlyRepository<String, ActionSetRegistration, ReadError = anyhow::Error>
+    + UpsertRepository<String, ActionSetRegistration, Error = anyhow::Error>
+    + CanDelete<String, ActionSetRegistration, DeleteError = anyhow::Error>
 {
 }
 

--- a/src/services/repositories/action_repository/tests.rs
+++ b/src/services/repositories/action_repository/tests.rs
@@ -80,7 +80,7 @@ async fn test_create_read_document(ctx: &mut ActionRepositoryTestContext) {
     };
 
     ctx.repository
-        .upsert("action-discovery-document".to_string(), spec.clone())
+        .upsert("action-discovery-document".to_string(), spec.clone().into())
         .await
         .unwrap();
 
@@ -111,7 +111,7 @@ async fn test_create_read_path(ctx: &mut ActionRepositoryTestContext) {
     };
 
     ctx.repository
-        .upsert("action-discovery-document".to_string(), spec.clone())
+        .upsert("action-discovery-document".to_string(), spec.clone().into())
         .await
         .unwrap();
 
@@ -143,7 +143,7 @@ async fn test_reacts_on_deletions(ctx: &mut ActionRepositoryTestContext) {
     };
 
     ctx.repository
-        .upsert("action-discovery-document-deleted".to_string(), spec.clone())
+        .upsert("action-discovery-document-deleted".to_string(), spec.clone().into())
         .await
         .unwrap();
 

--- a/src/services/repositories/models.rs
+++ b/src/services/repositories/models.rs
@@ -36,6 +36,7 @@ impl TryFrom<RequestContext> for Vec<RequestSegment> {
 }
 
 #[derive(Debug, PartialEq, Eq, Ord, PartialOrd, Clone, EnumString, Serialize, Deserialize, JsonSchema, Display)]
+#[strum(serialize_all = "UPPERCASE")]
 pub enum HTTPMethod {
     #[strum(ascii_case_insensitive)]
     Get,

--- a/src/services/repositories/models.rs
+++ b/src/services/repositories/models.rs
@@ -35,7 +35,7 @@ impl TryFrom<RequestContext> for Vec<RequestSegment> {
     }
 }
 
-#[derive(Debug, PartialEq, Eq, Ord, PartialOrd, Clone, EnumString, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, PartialEq, Eq, Ord, PartialOrd, Clone, EnumString, Serialize, Deserialize, JsonSchema, Display)]
 pub enum HTTPMethod {
     #[strum(ascii_case_insensitive)]
     Get,


### PR DESCRIPTION
Part of https://github.com/SneaksAndData/terraform-provider-boxer/issues/12, https://github.com/SneaksAndData/terraform-provider-boxer/issues/7

## Scope

Implemented:
- Exposed the `action_set` API for provider.

Additional changes:
- Entity type in `ReadOnlyRepository<String, ActionDiscoveryDocumentSpec>` was changed to `ActionSetRegistration`

## Checklist

- [ ] GitHub issue exists for this change.
- [ ] Unit tests added and they pass.
- [ ] Line Coverage is at least 80%.
- [ ] Review requested on `latest` commit.