### PR TITLE
Bind schema-related objects to the schema

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -583,7 +583,7 @@ dependencies = [
 [[package]]
 name = "boxer_core"
 version = "0.1.0"
-source = "git+https://github.com/SneaksAndData/boxer-core.git?tag=v0.0.5#e942d5e242d89def722acf20b65e4b84984da249"
+source = "git+https://github.com/SneaksAndData/boxer-core.git?branch=add-to-object-ref#0f547af751b02b34d504e53377f41c9e3f8d3f0d"
 dependencies = [
  "actix-web",
  "anyhow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -583,7 +583,7 @@ dependencies = [
 [[package]]
 name = "boxer_core"
 version = "0.1.0"
-source = "git+https://github.com/SneaksAndData/boxer-core.git?branch=add-to-object-ref#0f547af751b02b34d504e53377f41c9e3f8d3f0d"
+source = "git+https://github.com/SneaksAndData/boxer-core.git?tag=v0.0.6#929be3828b43af2e99bd55329dd7fe1b3573ff50"
 dependencies = [
  "actix-web",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ futures = "0.3.31"
 utoipa-swagger-ui = { version = "9", features = ["actix-web"] }
 schemars = "0.8.6"
 #boxer_core = { path = "../boxer-core/" }
-boxer_core = { git = "https://github.com/SneaksAndData/boxer-core.git", tag = "v0.0.5" }
+boxer_core = { git = "https://github.com/SneaksAndData/boxer-core.git", branch = "add-to-object-ref" }
 
 [dev-dependencies]
 rstest = "0.25.0"
@@ -39,5 +39,5 @@ test-context = "0.4.1"
 # This line is for development, to be removed in the future,
 #before moving to production
 #boxer_core = { path = "../boxer-core/" }
-boxer_core = { git = "https://github.com/SneaksAndData/boxer-core.git", tag = "v0.0.5" }
+boxer_core = { git = "https://github.com/SneaksAndData/boxer-core.git", branch = "add-to-object-ref" }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ futures = "0.3.31"
 utoipa-swagger-ui = { version = "9", features = ["actix-web"] }
 schemars = "0.8.6"
 #boxer_core = { path = "../boxer-core/" }
-boxer_core = { git = "https://github.com/SneaksAndData/boxer-core.git", branch = "add-to-object-ref" }
+boxer_core = { git = "https://github.com/SneaksAndData/boxer-core.git", tag = "v0.0.6" }
 
 [dev-dependencies]
 rstest = "0.25.0"
@@ -39,5 +39,4 @@ test-context = "0.4.1"
 # This line is for development, to be removed in the future,
 #before moving to production
 #boxer_core = { path = "../boxer-core/" }
-boxer_core = { git = "https://github.com/SneaksAndData/boxer-core.git", branch = "add-to-object-ref" }
-
+boxer_core = { git = "https://github.com/SneaksAndData/boxer-core.git", tag = "v0.0.6" }

--- a/integration-tests/helm/integration_tests/Chart.lock
+++ b/integration-tests/helm/integration_tests/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: boxer-crd
   repository: oci://ghcr.io/sneaksanddata/helm
-  version: v0.0.0-5-g054dcff
-digest: sha256:0b6286cf8aaf50ae2e9e59612404ed8bcc76e13085200844c6bd66d8a18dd986
-generated: "2025-08-06T09:56:35.118945+02:00"
+  version: v0.0.2-3-g9c16c1a
+digest: sha256:a57988229d4cf316450b0a997aad1f963ad638176e4e18d6af7a9d541defa7a0
+generated: "2025-08-18T17:36:12.413268+02:00"

--- a/integration-tests/helm/integration_tests/Chart.lock
+++ b/integration-tests/helm/integration_tests/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: boxer-crd
   repository: oci://ghcr.io/sneaksanddata/helm
-  version: v0.0.2-3-g9c16c1a
-digest: sha256:a57988229d4cf316450b0a997aad1f963ad638176e4e18d6af7a9d541defa7a0
-generated: "2025-08-18T17:36:12.413268+02:00"
+  version: v0.0.3
+digest: sha256:28cd68355fb5fe312d6f8381b22613f06806053df54de3661dbee1a1080ba7da
+generated: "2025-08-18T17:39:51.543352+02:00"

--- a/integration-tests/helm/integration_tests/Chart.yaml
+++ b/integration-tests/helm/integration_tests/Chart.yaml
@@ -6,5 +6,5 @@ version: 0.0.0
 appVersion: "0.0.0"
 dependencies:
   - name: boxer-crd
-    version: "v0.0.0-5-g054dcff"
+    version: "v0.0.2-3-g9c16c1a"
     repository: "oci://ghcr.io/sneaksanddata/helm"

--- a/integration-tests/helm/integration_tests/Chart.yaml
+++ b/integration-tests/helm/integration_tests/Chart.yaml
@@ -6,5 +6,5 @@ version: 0.0.0
 appVersion: "0.0.0"
 dependencies:
   - name: boxer-crd
-    version: "v0.0.2-3-g9c16c1a"
+    version: "v0.0.3"
     repository: "oci://ghcr.io/sneaksanddata/helm"

--- a/settings.toml
+++ b/settings.toml
@@ -14,7 +14,3 @@ lease_duration = "60s"                   # Duration string for lease lifetime
 lease_renew_duration = "15s"             # Duration string for lease renewal interval
 resource_owner_label = "local.debug"     # Label to identify resources created by this instance
 operation_timeout = "30s"                # Timeout for operations on the backend operations
-
-# Repository settings for schemas
-[backend.kubernetes.schema_repository]
-name = "boxer-validator-schema"

--- a/settings.toml
+++ b/settings.toml
@@ -1,6 +1,8 @@
 # Application settings
 instance_name = "integration-tests"
 
+listen_address = "127.0.0.1:8081"
+
 [backend]
 # Kubernetes backend settings
 [backend.kubernetes]
@@ -10,6 +12,8 @@ namespace = "default"                    # Kubernetes namespace
 lease_name = "boxer-validator"           # Name for the lease object
 lease_duration = "60s"                   # Duration string for lease lifetime
 lease_renew_duration = "15s"             # Duration string for lease renewal interval
+resource_owner_label = "local.debug"     # Label to identify resources created by this instance
+operation_timeout = "30s"                # Timeout for operations on the backend operations
 
 # Repository settings for schemas
 [backend.kubernetes.schema_repository]

--- a/src/http/controllers/action_set.rs
+++ b/src/http/controllers/action_set.rs
@@ -8,27 +8,30 @@ use actix_web::{delete, get, post, web, HttpResponse, Responder, Result};
 use std::sync::Arc;
 
 #[utoipa::path(context_path = "/action_set/", responses((status = OK)), request_body = ActionSetRegistration)]
-#[post("{id}")]
+#[post("{schema}/{id}")]
 async fn post_action_set(
-    id: Path<String>,
+    id: Path<(String, String)>,
     request: Json<ActionSetRegistration>,
     data: Data<Arc<ActionDataRepository>>,
 ) -> Result<impl Responder> {
-    data.upsert(id.to_string(), request.into_inner()).await?;
+    data.upsert(id.into_inner(), request.into_inner()).await?;
     Ok(HttpResponse::Ok().finish())
 }
 
 #[utoipa::path(context_path = "/action_set/", responses((status = OK, body = ActionSetRegistration)))]
-#[get("{id}")]
-async fn get_action_set(id: Path<String>, data: Data<Arc<ActionDataRepository>>) -> Result<impl Responder> {
-    let action_set = data.get(id.to_string()).await?;
+#[get("{schema}/{id}")]
+async fn get_action_set(id: Path<(String, String)>, data: Data<Arc<ActionDataRepository>>) -> Result<impl Responder> {
+    let action_set = data.get(id.into_inner()).await?;
     Ok(Json(action_set))
 }
 
 #[utoipa::path(context_path = "/action_set/", responses((status = OK)))]
-#[delete("{id}")]
-async fn delete_action_set(id: Path<String>, data: Data<Arc<ActionDataRepository>>) -> Result<impl Responder> {
-    data.delete(id.to_string()).await?;
+#[delete("{schema}/{id}")]
+async fn delete_action_set(
+    id: Path<(String, String)>,
+    data: Data<Arc<ActionDataRepository>>,
+) -> Result<impl Responder> {
+    data.delete(id.into_inner()).await?;
     Ok(HttpResponse::Ok().finish())
 }
 

--- a/src/http/controllers/action_set.rs
+++ b/src/http/controllers/action_set.rs
@@ -14,14 +14,16 @@ async fn post_action_set(
     request: Json<ActionSetRegistration>,
     data: Data<Arc<ActionDataRepository>>,
 ) -> Result<impl Responder> {
-    data.upsert(id.into_inner(), request.into_inner()).await?;
+    let (id, schema) = id.into_inner();
+    data.upsert((id, schema.clone()), request.into_inner().with_schema(schema))
+        .await?;
     Ok(HttpResponse::Ok().finish())
 }
 
 #[utoipa::path(context_path = "/action_set/", responses((status = OK, body = ActionSetRegistration)))]
 #[get("{schema}/{id}")]
 async fn get_action_set(id: Path<(String, String)>, data: Data<Arc<ActionDataRepository>>) -> Result<impl Responder> {
-    let action_set = data.get(id.into_inner()).await?;
+    let action_set: ActionSetRegistration = data.get(id.into_inner()).await?.into();
     Ok(Json(action_set))
 }
 

--- a/src/http/controllers/action_set.rs
+++ b/src/http/controllers/action_set.rs
@@ -7,7 +7,12 @@ use actix_web::web::{Data, Json, Path};
 use actix_web::{delete, get, post, web, HttpResponse, Responder, Result};
 use std::sync::Arc;
 
-#[utoipa::path(context_path = "/action_set/", responses((status = OK)), request_body = ActionSetRegistration)]
+#[utoipa::path(context_path = "/action_set/",
+    responses(
+        (status = OK)
+    ),
+    request_body = ActionSetRegistration
+)]
 #[post("{schema}/{id}")]
 async fn post_action_set(
     id: Path<(String, String)>,
@@ -20,14 +25,23 @@ async fn post_action_set(
     Ok(HttpResponse::Ok().finish())
 }
 
-#[utoipa::path(context_path = "/action_set/", responses((status = OK, body = ActionSetRegistration)))]
+#[utoipa::path(context_path = "/action_set/",
+    responses(
+        (status = OK, body = ActionSetRegistration),
+        (status = NOT_FOUND, description = "Action set does not exist")
+    )
+)]
 #[get("{schema}/{id}")]
 async fn get_action_set(id: Path<(String, String)>, data: Data<Arc<ActionDataRepository>>) -> Result<impl Responder> {
     let action_set: ActionSetRegistration = data.get(id.into_inner()).await?.into();
     Ok(Json(action_set))
 }
 
-#[utoipa::path(context_path = "/action_set/", responses((status = OK)))]
+#[utoipa::path(context_path = "/action_set/",
+    responses(
+        (status = OK)
+    )
+)]
 #[delete("{schema}/{id}")]
 async fn delete_action_set(
     id: Path<(String, String)>,

--- a/src/http/controllers/action_set/models.rs
+++ b/src/http/controllers/action_set/models.rs
@@ -25,7 +25,23 @@ pub struct ActionSetRegistration {
     pub routes: Vec<ActionRouteRegistration>,
 }
 
-impl TryFromResource<ActionDiscoveryDocument> for ActionSetRegistration {
+impl ActionSetRegistration {
+    pub fn with_schema(self, schema: String) -> SchemaBoundActionSetRegistration {
+        SchemaBoundActionSetRegistration {
+            hostname: self.hostname,
+            routes: self.routes,
+            schema,
+        }
+    }
+}
+
+pub struct SchemaBoundActionSetRegistration {
+    pub hostname: String,
+    pub routes: Vec<ActionRouteRegistration>,
+    pub schema: String,
+}
+
+impl TryFromResource<ActionDiscoveryDocument> for SchemaBoundActionSetRegistration {
     type Error = Status;
 
     fn try_into_resource(resource: Arc<ActionDiscoveryDocument>) -> Result<Self, Self::Error> {
@@ -35,7 +51,7 @@ impl TryFromResource<ActionDiscoveryDocument> for ActionSetRegistration {
     }
 }
 
-impl ToResource<ActionDiscoveryDocument> for ActionSetRegistration {
+impl ToResource<ActionDiscoveryDocument> for SchemaBoundActionSetRegistration {
     fn to_resource(&self, object_meta: &ObjectMeta) -> Result<ActionDiscoveryDocument, Status> {
         let spec =
             ActionDiscoveryDocumentSpec::try_from(self).map_err(|e| Status::ConversionError(anyhow::Error::from(e)))?;
@@ -43,5 +59,14 @@ impl ToResource<ActionDiscoveryDocument> for ActionSetRegistration {
             metadata: object_meta.clone(),
             spec,
         })
+    }
+}
+
+impl Into<ActionSetRegistration> for SchemaBoundActionSetRegistration {
+    fn into(self) -> ActionSetRegistration {
+        ActionSetRegistration {
+            hostname: self.hostname,
+            routes: self.routes,
+        }
     }
 }

--- a/src/http/controllers/policy_set.rs
+++ b/src/http/controllers/policy_set.rs
@@ -15,14 +15,16 @@ async fn post_policy_set(
     request: Json<PolicySetRegistration>,
     data: Data<Arc<PolicyDataRepository>>,
 ) -> Result<impl Responder> {
-    data.upsert(id.into_inner(), request.into_inner()).await?;
+    let (id, schema) = id.into_inner();
+    data.upsert((id, schema.clone()), request.into_inner().with_schema(schema))
+        .await?;
     Ok(HttpResponse::Ok().finish())
 }
 
 #[utoipa::path(context_path = "/policy_set/", responses((status = OK, body = PolicySetRegistration)))]
 #[get("{schema}/{id}")]
 async fn get_policy_set(id: Path<(String, String)>, data: Data<Arc<PolicyDataRepository>>) -> Result<impl Responder> {
-    let policy_set = data.get(id.into_inner()).await?;
+    let policy_set: PolicySetRegistration = data.get(id.into_inner()).await?.into();
     Ok(Json(policy_set))
 }
 

--- a/src/http/controllers/policy_set.rs
+++ b/src/http/controllers/policy_set.rs
@@ -8,7 +8,12 @@ use actix_web::Result;
 use actix_web::{delete, get, post, web, HttpResponse, Responder};
 use std::sync::Arc;
 
-#[utoipa::path(context_path = "/policy_set/", responses((status = OK)), request_body = PolicySetRegistration)]
+#[utoipa::path(context_path = "/policy_set/",
+    responses(
+        (status = OK)
+    ),
+    request_body = PolicySetRegistration
+)]
 #[post("{schema}/{id}")]
 async fn post_policy_set(
     id: Path<(String, String)>,
@@ -21,14 +26,23 @@ async fn post_policy_set(
     Ok(HttpResponse::Ok().finish())
 }
 
-#[utoipa::path(context_path = "/policy_set/", responses((status = OK, body = PolicySetRegistration)))]
+#[utoipa::path(context_path = "/policy_set/",
+    responses(
+        (status = OK, body = PolicySetRegistration),
+        (status = NOT_FOUND, description = "Policy set does not exist")
+    )
+)]
 #[get("{schema}/{id}")]
 async fn get_policy_set(id: Path<(String, String)>, data: Data<Arc<PolicyDataRepository>>) -> Result<impl Responder> {
     let policy_set: PolicySetRegistration = data.get(id.into_inner()).await?.into();
     Ok(Json(policy_set))
 }
 
-#[utoipa::path(context_path = "/policy_set/", responses((status = OK)))]
+#[utoipa::path(context_path = "/policy_set/",
+    responses(
+        (status = OK)
+    )
+)]
 #[delete("{schema}/{id}")]
 async fn delete_policy_set(
     id: Path<(String, String)>,

--- a/src/http/controllers/policy_set.rs
+++ b/src/http/controllers/policy_set.rs
@@ -9,27 +9,30 @@ use actix_web::{delete, get, post, web, HttpResponse, Responder};
 use std::sync::Arc;
 
 #[utoipa::path(context_path = "/policy_set/", responses((status = OK)), request_body = PolicySetRegistration)]
-#[post("{id}")]
+#[post("{schema}/{id}")]
 async fn post_policy_set(
-    id: Path<String>,
+    id: Path<(String, String)>,
     request: Json<PolicySetRegistration>,
     data: Data<Arc<PolicyDataRepository>>,
 ) -> Result<impl Responder> {
-    data.upsert(id.to_string(), request.into_inner()).await?;
+    data.upsert(id.into_inner(), request.into_inner()).await?;
     Ok(HttpResponse::Ok().finish())
 }
 
 #[utoipa::path(context_path = "/policy_set/", responses((status = OK, body = PolicySetRegistration)))]
-#[get("{id}")]
-async fn get_policy_set(id: Path<String>, data: Data<Arc<PolicyDataRepository>>) -> Result<impl Responder> {
-    let policy_set = data.get(id.to_string()).await?;
+#[get("{schema}/{id}")]
+async fn get_policy_set(id: Path<(String, String)>, data: Data<Arc<PolicyDataRepository>>) -> Result<impl Responder> {
+    let policy_set = data.get(id.into_inner()).await?;
     Ok(Json(policy_set))
 }
 
 #[utoipa::path(context_path = "/policy_set/", responses((status = OK)))]
-#[delete("{id}")]
-async fn delete_policy_set(id: Path<String>, data: Data<Arc<PolicyDataRepository>>) -> Result<impl Responder> {
-    data.delete(id.to_string()).await?;
+#[delete("{schema}/{id}")]
+async fn delete_policy_set(
+    id: Path<(String, String)>,
+    data: Data<Arc<PolicyDataRepository>>,
+) -> Result<impl Responder> {
+    data.delete(id.into_inner()).await?;
     Ok(HttpResponse::Ok().finish())
 }
 

--- a/src/http/controllers/policy_set/models.rs
+++ b/src/http/controllers/policy_set/models.rs
@@ -13,6 +13,34 @@ pub struct PolicySetRegistration {
     pub policy: String,
 }
 
+impl PolicySetRegistration {
+    pub fn with_schema(self, schema: String) -> SchemaBoundPolicySetRegistration {
+        SchemaBoundPolicySetRegistration {
+            policy: self.policy.clone(),
+            schema,
+        }
+    }
+}
+
+pub struct SchemaBoundPolicySetRegistration {
+    pub policy: String,
+    pub schema: String,
+}
+
+impl ToResource<PolicyDocument> for SchemaBoundPolicySetRegistration {
+    fn to_resource(&self, object_meta: &ObjectMeta) -> Result<PolicyDocument, Status> {
+        let spec = PolicyDocumentSpec {
+            active: true,
+            policies: self.policy.clone(),
+            schema: self.schema.clone(),
+        };
+        Ok(PolicyDocument {
+            metadata: object_meta.clone(),
+            spec,
+        })
+    }
+}
+
 impl Default for PolicySetRegistration {
     fn default() -> Self {
         PolicySetRegistration {
@@ -21,7 +49,7 @@ impl Default for PolicySetRegistration {
     }
 }
 
-impl TryFromResource<PolicyDocument> for PolicySetRegistration {
+impl TryFromResource<PolicyDocument> for SchemaBoundPolicySetRegistration {
     type Error = Status;
 
     fn try_into_resource(resource: Arc<PolicyDocument>) -> Result<Self, Self::Error> {
@@ -31,15 +59,8 @@ impl TryFromResource<PolicyDocument> for PolicySetRegistration {
     }
 }
 
-impl ToResource<PolicyDocument> for PolicySetRegistration {
-    fn to_resource(&self, object_meta: &ObjectMeta) -> Result<PolicyDocument, Status> {
-        let spec = PolicyDocumentSpec {
-            active: true,
-            policies: self.policy.clone(),
-        };
-        Ok(PolicyDocument {
-            metadata: object_meta.clone(),
-            spec,
-        })
+impl Into<PolicySetRegistration> for SchemaBoundPolicySetRegistration {
+    fn into(self) -> PolicySetRegistration {
+        PolicySetRegistration { policy: self.policy }
     }
 }

--- a/src/http/controllers/resource_set.rs
+++ b/src/http/controllers/resource_set.rs
@@ -7,7 +7,12 @@ use actix_web::web::{Data, Json, Path};
 use actix_web::{delete, get, post, web, HttpResponse, Responder, Result};
 use std::sync::Arc;
 
-#[utoipa::path(context_path = "/resource_set/", responses((status = OK)), request_body = ResourceSetRegistration)]
+#[utoipa::path(context_path = "/resource_set/",
+    responses(
+        (status = OK)
+    ),
+    request_body = ResourceSetRegistration
+)]
 #[post("{schema}/{id}")]
 async fn post_resource_set(
     id: Path<(String, String)>,
@@ -20,7 +25,12 @@ async fn post_resource_set(
     Ok(HttpResponse::Ok().finish())
 }
 
-#[utoipa::path(context_path = "/resource_set/", responses((status = OK, body = ResourceSetRegistration)))]
+#[utoipa::path(context_path = "/resource_set/",
+    responses(
+        (status = OK, body = ResourceSetRegistration),
+        (status = NOT_FOUND, description = "Resource set does not exist")
+    )
+)]
 #[get("{schema}/{id}")]
 async fn get_resource_set(
     id: Path<(String, String)>,
@@ -30,7 +40,11 @@ async fn get_resource_set(
     Ok(Json(resource_set))
 }
 
-#[utoipa::path(context_path = "/resource_set/", responses((status = OK)))]
+#[utoipa::path(context_path = "/resource_set/",
+    responses(
+        (status = OK)
+    )
+)]
 #[delete("{schema}/{id}")]
 async fn delete_resource_set(
     id: Path<(String, String)>,

--- a/src/http/controllers/resource_set.rs
+++ b/src/http/controllers/resource_set.rs
@@ -8,33 +8,33 @@ use actix_web::{delete, get, post, web, HttpResponse, Responder, Result};
 use std::sync::Arc;
 
 #[utoipa::path(context_path = "/resource_set/", responses((status = OK)), request_body = ResourceSetRegistration)]
-#[post("{id}")]
+#[post("{schema}/{id}")]
 async fn post_resource_set(
-    id: Path<String>,
+    id: Path<(String, String)>,
     request: Json<ResourceSetRegistration>,
     data: Data<Arc<ResourceDiscoveryDocumentRepository>>,
 ) -> Result<impl Responder> {
-    data.upsert(id.to_string(), request.into_inner()).await?;
+    data.upsert(id.into_inner(), request.into_inner()).await?;
     Ok(HttpResponse::Ok().finish())
 }
 
 #[utoipa::path(context_path = "/resource_set/", responses((status = OK, body = ResourceSetRegistration)))]
-#[get("{id}")]
+#[get("{schema}/{id}")]
 async fn get_resource_set(
-    id: Path<String>,
+    id: Path<(String, String)>,
     data: Data<Arc<ResourceDiscoveryDocumentRepository>>,
 ) -> Result<impl Responder> {
-    let resource_set = data.get(id.to_string()).await?;
+    let resource_set = data.get(id.into_inner()).await?;
     Ok(Json(resource_set))
 }
 
 #[utoipa::path(context_path = "/resource_set/", responses((status = OK)))]
-#[delete("{id}")]
+#[delete("{schema}/{id}")]
 async fn delete_resource_set(
-    id: Path<String>,
+    id: Path<(String, String)>,
     data: Data<Arc<ResourceDiscoveryDocumentRepository>>,
 ) -> Result<impl Responder> {
-    data.delete(id.to_string()).await?;
+    data.delete(id.into_inner()).await?;
     Ok(HttpResponse::Ok().finish())
 }
 

--- a/src/http/controllers/resource_set.rs
+++ b/src/http/controllers/resource_set.rs
@@ -14,7 +14,9 @@ async fn post_resource_set(
     request: Json<ResourceSetRegistration>,
     data: Data<Arc<ResourceDiscoveryDocumentRepository>>,
 ) -> Result<impl Responder> {
-    data.upsert(id.into_inner(), request.into_inner()).await?;
+    let (id, schema) = id.into_inner();
+    data.upsert((id, schema.clone()), request.into_inner().with_schema(schema))
+        .await?;
     Ok(HttpResponse::Ok().finish())
 }
 
@@ -24,7 +26,7 @@ async fn get_resource_set(
     id: Path<(String, String)>,
     data: Data<Arc<ResourceDiscoveryDocumentRepository>>,
 ) -> Result<impl Responder> {
-    let resource_set = data.get(id.into_inner()).await?;
+    let resource_set: ResourceSetRegistration = data.get(id.into_inner()).await?.into();
     Ok(Json(resource_set))
 }
 

--- a/src/http/controllers/schema.rs
+++ b/src/http/controllers/schema.rs
@@ -6,7 +6,12 @@ use cedar_policy::SchemaFragment;
 use serde_json::Value;
 use std::sync::Arc;
 
-#[utoipa::path(context_path = "/schema/", responses((status = OK)), request_body = Value)]
+#[utoipa::path(context_path = "/schema/",
+    responses(
+        (status = OK),
+    ),
+    request_body = Value
+)]
 #[post("{id}")]
 async fn post_schema(
     id: Path<String>,
@@ -19,7 +24,12 @@ async fn post_schema(
     Ok(HttpResponse::Ok().finish())
 }
 
-#[utoipa::path(context_path = "/schema/", responses((status = OK, body = Value)))]
+#[utoipa::path(context_path = "/schema/",
+    responses(
+        (status = OK, body = Value),
+        (status = NOT_FOUND, description = "Schema does not exist")
+    )
+)]
 #[get("{id}")]
 async fn get_schema(id: Path<String>, data: Data<Arc<SchemaRepository>>) -> Result<impl Responder> {
     let schema = data.get(id.to_string()).await?;
@@ -29,7 +39,11 @@ async fn get_schema(id: Path<String>, data: Data<Arc<SchemaRepository>>) -> Resu
     Ok(Json(result))
 }
 
-#[utoipa::path(context_path = "/schema/", responses((status = OK)))]
+#[utoipa::path(context_path = "/schema/",
+    responses(
+        (status = OK)
+    )
+)]
 #[delete("{id}")]
 async fn delete_schema(id: Path<String>, data: Data<Arc<SchemaRepository>>) -> Result<impl Responder> {
     data.delete(id.to_string()).await?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,10 +34,7 @@ async fn main() -> Result<()> {
         .configure(&cm.backend.kubernetes, cm.instance_name.clone())
         .await?;
 
-    let schema_provider = Arc::new(KubernetesSchemaProvider::new(
-        current_backend.get(),
-        cm.backend.kubernetes.schema_repository.name,
-    ));
+    let schema_provider = Arc::new(KubernetesSchemaProvider::new(current_backend.get()));
     let action_repository = current_backend.get();
     let resource_repository = current_backend.get();
     let policy_repository = current_backend.get();

--- a/src/services/backends/kubernetes.rs
+++ b/src/services/backends/kubernetes.rs
@@ -4,9 +4,6 @@ use crate::services::repositories::action_repository::action_discovery_document:
 use crate::services::repositories::action_repository::read_write::ActionDataRepository;
 use crate::services::repositories::action_repository::ActionReadOnlyRepository;
 use crate::services::repositories::lookup_trie::backend::ReadOnlyRepositoryBackend;
-use crate::services::repositories::lookup_trie::TrieRepositoryData;
-use crate::services::repositories::models::path_segment::PathSegment;
-use crate::services::repositories::models::request_segment::RequestSegment;
 use crate::services::repositories::policy_repository::policy_document::PolicyDocument;
 use crate::services::repositories::policy_repository::read_only::PolicyRepositoryData;
 use crate::services::repositories::policy_repository::read_write::PolicyDataRepository;
@@ -25,10 +22,9 @@ pub struct KubernetesBackend {
     resource_repository: Arc<ResourceDiscoveryDocumentRepository>,
     policy_repository: Arc<PolicyDataRepository>,
 
-    action_lookup_table_listener:
-        Arc<ReadOnlyRepositoryBackend<TrieRepositoryData<RequestSegment>, ActionDiscoveryDocument>>,
+    action_lookup_table_listener: Arc<ReadOnlyRepositoryBackend<ActionReadOnlyRepository, ActionDiscoveryDocument>>,
     resource_lookup_table_listener:
-        Arc<ReadOnlyRepositoryBackend<TrieRepositoryData<PathSegment>, ResourceDiscoveryDocument>>,
+        Arc<ReadOnlyRepositoryBackend<ResourceReadOnlyRepository, ResourceDiscoveryDocument>>,
     policy_lookup_watcher: Arc<ReadOnlyRepositoryBackend<PolicyRepositoryData, PolicyDocument>>,
 }
 

--- a/src/services/backends/kubernetes/configuration.rs
+++ b/src/services/backends/kubernetes/configuration.rs
@@ -3,7 +3,8 @@ use crate::services::backends::BackendBuilder;
 use crate::services::configuration::models::KubernetesBackendSettings;
 use crate::services::repositories::action_repository::read_write::ActionDataRepository;
 use crate::services::repositories::lookup_trie::backend::ReadOnlyRepositoryBackend;
-use crate::services::repositories::lookup_trie::{EntityCollectionResource, TrieRepositoryData};
+use crate::services::repositories::lookup_trie::schema_bound_trie_repository::SchemaBoundedTrieRepositoryData;
+use crate::services::repositories::lookup_trie::{EntityCollectionResource, SchemaBoundResource};
 use crate::services::repositories::models::path_segment::PathSegment;
 use crate::services::repositories::policy_repository;
 use crate::services::repositories::policy_repository::policy_document::PolicyDocument;
@@ -163,7 +164,7 @@ impl BackendBuilder {
         kubeconfig: Config,
         owner_mark: ObjectOwnerMark,
         operation_timeout: Duration,
-    ) -> anyhow::Result<Arc<ReadOnlyRepositoryBackend<TrieRepositoryData<K>, R>>>
+    ) -> anyhow::Result<Arc<ReadOnlyRepositoryBackend<SchemaBoundedTrieRepositoryData<K>, R>>>
     where
         K: Debug + Ord + Clone + Send + Sync + Hash + 'static,
         R: kube::Resource<Scope = NamespaceResourceScope>
@@ -171,6 +172,7 @@ impl BackendBuilder {
             + EntityCollectionResource<K>
             + UpdateLabels
             + Clone
+            + SchemaBoundResource
             + Send
             + Sync
             + 'static,
@@ -182,8 +184,8 @@ impl BackendBuilder {
             owner_mark,
             operation_timeout,
         };
-        let lookup_trie = Arc::new(TrieRepositoryData::<K>::new());
-        let r = ReadOnlyRepositoryBackend::<TrieRepositoryData<K>, R>::start(config, lookup_trie).await?;
+        let lookup_trie = Arc::new(SchemaBoundedTrieRepositoryData::<K>::new());
+        let r = ReadOnlyRepositoryBackend::<SchemaBoundedTrieRepositoryData<K>, R>::start(config, lookup_trie).await?;
         Ok(Arc::new(r))
     }
 

--- a/src/services/cedar_validation_service.rs
+++ b/src/services/cedar_validation_service.rs
@@ -6,6 +6,7 @@ use crate::services::repositories::action_repository::ActionReadOnlyRepository;
 use crate::services::repositories::policy_repository::PolicyReadOnlyRepository;
 use crate::services::repositories::resource_repository::ResourceReadOnlyRepository;
 use async_trait::async_trait;
+use boxer_core::services::base::upsert_repository::ReadOnlyRepository;
 use cedar_policy::{Authorizer, Context, Entities, Entity, EntityUid, Request};
 use log::{debug, info};
 use std::sync::Arc;
@@ -41,11 +42,14 @@ impl ValidationService for CedarValidationService {
         let schema = self.schema_provider.get_schema(&boxer_claims).await?;
         debug!("Cedar validation schemas: {:?}", schema);
 
-        let action = self.action_repository.get(request_context.clone().try_into()?).await?;
+        let action = self
+            .action_repository
+            .get((boxer_claims.schema.clone(), request_context.clone().try_into()?))
+            .await?;
 
         let resource = self
             .resource_repository
-            .get(request_context.clone().try_into()?)
+            .get((boxer_claims.schema.clone(), request_context.clone().try_into()?))
             .await?;
 
         let policy_set = self.policy_repository.get(()).await?;

--- a/src/services/cedar_validation_service.rs
+++ b/src/services/cedar_validation_service.rs
@@ -52,7 +52,7 @@ impl ValidationService for CedarValidationService {
             .get((boxer_claims.schema.clone(), request_context.clone().try_into()?))
             .await?;
 
-        let policy_set = self.policy_repository.get(()).await?;
+        let policy_set = self.policy_repository.get(boxer_claims.schema.clone()).await?;
 
         let actor: EntityUid = boxer_claims.try_into()?;
 

--- a/src/services/configuration/models.rs
+++ b/src/services/configuration/models.rs
@@ -3,17 +3,11 @@ use serde::Deserialize;
 use std::net::SocketAddr;
 
 #[derive(Debug, Deserialize)]
-pub struct SchemaRepositorySettings {
-    pub name: String,
-}
-
-#[derive(Debug, Deserialize)]
 pub struct KubernetesBackendSettings {
     pub kubeconfig: Option<String>,
     pub exec: Option<String>,
     pub in_cluster: bool,
     pub namespace: String,
-    pub schema_repository: SchemaRepositorySettings,
     pub resource_owner_label: String,
     pub operation_timeout: DurationString,
 }

--- a/src/services/repositories/action_repository.rs
+++ b/src/services/repositories/action_repository.rs
@@ -4,19 +4,7 @@ pub mod read_write;
 #[cfg(test)]
 mod tests;
 
-use crate::services::repositories::action_repository::action_discovery_document::ActionDiscoveryDocument;
-use crate::services::repositories::lookup_trie::TrieRepositoryData;
+use crate::services::repositories::lookup_trie::schema_bound_trie_repository::SchemaBoundedTrieRepositoryData;
 use crate::services::repositories::models::request_segment::RequestSegment;
-use boxer_core::services::backends::kubernetes::kubernetes_resource_watcher::ResourceUpdateHandler;
-use boxer_core::services::base::upsert_repository::ReadOnlyRepository;
-use cedar_policy::EntityUid;
 
-pub trait ActionReadOnlyRepositoryInterface:
-    ReadOnlyRepository<Vec<RequestSegment>, EntityUid, ReadError = anyhow::Error>
-    + ResourceUpdateHandler<ActionDiscoveryDocument>
-{
-}
-
-impl ActionReadOnlyRepositoryInterface for TrieRepositoryData<RequestSegment> {}
-
-pub type ActionReadOnlyRepository = dyn ActionReadOnlyRepositoryInterface;
+pub type ActionReadOnlyRepository = SchemaBoundedTrieRepositoryData<RequestSegment>;

--- a/src/services/repositories/action_repository/read_write.rs
+++ b/src/services/repositories/action_repository/read_write.rs
@@ -5,11 +5,14 @@ use boxer_core::services::backends::kubernetes::repositories::KubernetesReposito
 use boxer_core::services::base::upsert_repository::UpsertRepositoryWithDelete;
 
 pub type ActionDataRepository = dyn UpsertRepositoryWithDelete<
-    String,
+    (String, String),
     ActionSetRegistration,
     DeleteError = Status,
     Error = Status,
     ReadError = Status,
 >;
 
-impl UpsertRepositoryWithDelete<String, ActionSetRegistration> for KubernetesRepository<ActionDiscoveryDocument> {}
+impl UpsertRepositoryWithDelete<(String, String), ActionSetRegistration>
+    for KubernetesRepository<ActionDiscoveryDocument>
+{
+}

--- a/src/services/repositories/action_repository/read_write.rs
+++ b/src/services/repositories/action_repository/read_write.rs
@@ -1,4 +1,4 @@
-use crate::http::controllers::action_set::models::ActionSetRegistration;
+use crate::http::controllers::action_set::models::SchemaBoundActionSetRegistration;
 use crate::services::repositories::action_repository::action_discovery_document::ActionDiscoveryDocument;
 use boxer_core::services::backends::kubernetes::kubernetes_resource_manager::status::Status;
 use boxer_core::services::backends::kubernetes::repositories::KubernetesRepository;
@@ -6,13 +6,13 @@ use boxer_core::services::base::upsert_repository::UpsertRepositoryWithDelete;
 
 pub type ActionDataRepository = dyn UpsertRepositoryWithDelete<
     (String, String),
-    ActionSetRegistration,
+    SchemaBoundActionSetRegistration,
     DeleteError = Status,
     Error = Status,
     ReadError = Status,
 >;
 
-impl UpsertRepositoryWithDelete<(String, String), ActionSetRegistration>
+impl UpsertRepositoryWithDelete<(String, String), SchemaBoundActionSetRegistration>
     for KubernetesRepository<ActionDiscoveryDocument>
 {
 }

--- a/src/services/repositories/action_repository/tests.rs
+++ b/src/services/repositories/action_repository/tests.rs
@@ -7,7 +7,7 @@ use boxer_core::services::backends::kubernetes::kubernetes_resource_manager::Kub
 use boxer_core::services::backends::kubernetes::kubernetes_resource_watcher::KubernetesResourceWatcher;
 use boxer_core::services::backends::kubernetes::repositories::KubernetesRepository;
 use boxer_core::services::service_provider::ServiceProvider;
-use boxer_core::testing::api_extensions::WaitForResource;
+use boxer_core::testing::api_extensions::{WaitForDelete, WaitForResource};
 use boxer_core::testing::spin_lock_kubernetes_resource_manager_context::SpinLockKubernetesResourceManagerTestContext;
 use kube::Api;
 use std::sync::Arc;
@@ -145,6 +145,11 @@ async fn test_remove(ctx: &mut KubernetesActionRepositoryTest) {
         .delete(("schema".to_string(), "action-discovery-document-first".to_string()))
         .await
         .unwrap();
+
+    let key = format!("{}-{}", "schema", "action-discovery-document-first");
+    ctx.api
+        .wait_for_deletion::<ActionDiscoveryDocument>(key, ctx.namespace.clone(), DEFAULT_TEST_TIMEOUT)
+        .await;
 
     // Act
     let request_context = RequestContext::new(

--- a/src/services/repositories/action_repository/tests.rs
+++ b/src/services/repositories/action_repository/tests.rs
@@ -54,7 +54,7 @@ impl AsyncTestContext for KubernetesActionRepositoryTest {
 
 #[test_context(KubernetesActionRepositoryTest)]
 #[tokio::test]
-async fn test_create_schema(ctx: &mut KubernetesActionRepositoryTest) {
+async fn test_create_action_document(ctx: &mut KubernetesActionRepositoryTest) {
     // Arrange
 
     insert_schema_document(
@@ -77,6 +77,7 @@ async fn test_create_schema(ctx: &mut KubernetesActionRepositoryTest) {
     // Assert
     assert!(result.is_ok());
 }
+
 #[test_context(KubernetesActionRepositoryTest)]
 #[tokio::test]
 async fn test_multiple_actions(ctx: &mut KubernetesActionRepositoryTest) {
@@ -172,8 +173,8 @@ async fn insert_schema_document(ctx: &KubernetesActionRepositoryTest, name: &str
         .await
         .expect("Failed to upsert schema");
 
-    // Act
+    let key = format!("{}-{}", "schema", name);
     ctx.api
-        .wait_for_creation(name.to_string(), ctx.namespace.clone(), DEFAULT_TEST_TIMEOUT)
+        .wait_for_creation(key, ctx.namespace.clone(), DEFAULT_TEST_TIMEOUT)
         .await;
 }

--- a/src/services/repositories/action_repository/tests.rs
+++ b/src/services/repositories/action_repository/tests.rs
@@ -141,7 +141,7 @@ async fn test_remove(ctx: &mut KubernetesActionRepositoryTest) {
     let lookup_trie = ctx.lookup.get();
 
     ctx.repository
-        .delete("action-discovery-document-first".to_string())
+        .delete(("schema".to_string(), "action-discovery-document-first".to_string()))
         .await
         .unwrap();
 
@@ -168,7 +168,7 @@ async fn insert_schema_document(ctx: &KubernetesActionRepositoryTest, name: &str
     };
 
     ctx.repository
-        .upsert(name.to_string(), registration)
+        .upsert(("schema".to_string(), name.to_string()), registration)
         .await
         .expect("Failed to upsert schema");
 

--- a/src/services/repositories/lookup_trie.rs
+++ b/src/services/repositories/lookup_trie.rs
@@ -20,13 +20,14 @@ use tokio::sync::RwLock;
 use trie_rs::map::Trie;
 
 pub mod backend;
+pub mod schema_bound_trie_repository;
 
 pub struct TrieData<Key> {
     items: HashMap<Vec<Key>, EntityUid>,
     maybe_trie: Option<Arc<Trie<Key, EntityUid>>>,
 }
 
-pub struct TrieRepositoryData<Key> {
+struct TrieRepositoryData<Key> {
     pub rw_lock: RwLock<TrieData<Key>>,
 }
 
@@ -48,6 +49,10 @@ pub trait EntityCollectionResource<Key> {
     fn stream(
         self,
     ) -> impl futures::Stream<Item = Result<(Vec<Key>, EntityUid, bool), anyhow::Error>> + Send + Sync + 'static;
+}
+
+pub trait SchemaBoundResource {
+    fn schema(&self) -> String;
 }
 
 #[async_trait]

--- a/src/services/repositories/lookup_trie/schema_bound_trie_repository.rs
+++ b/src/services/repositories/lookup_trie/schema_bound_trie_repository.rs
@@ -1,0 +1,70 @@
+use crate::services::repositories::lookup_trie::{EntityCollectionResource, SchemaBoundResource, TrieRepositoryData};
+use anyhow::anyhow;
+
+use async_trait::async_trait;
+use boxer_core::services::backends::kubernetes::kubernetes_resource_watcher::ResourceUpdateHandler;
+use boxer_core::services::base::upsert_repository::ReadOnlyRepository;
+use cedar_policy::EntityUid;
+use kube::runtime::watcher;
+use kube::Resource;
+use log::warn;
+use std::collections::HashMap;
+use std::fmt::Debug;
+use std::hash::Hash;
+use tokio::sync::RwLock;
+
+pub struct SchemaBoundedTrieRepositoryData<Key>
+where
+    Key: Ord,
+{
+    pub buckets: RwLock<HashMap<String, TrieRepositoryData<Key>>>,
+}
+
+impl<Key> SchemaBoundedTrieRepositoryData<Key>
+where
+    Key: Ord,
+{
+    pub fn new() -> Self {
+        SchemaBoundedTrieRepositoryData {
+            buckets: RwLock::new(HashMap::new()),
+        }
+    }
+}
+
+#[async_trait]
+impl<Key> ReadOnlyRepository<(String, Vec<Key>), EntityUid> for SchemaBoundedTrieRepositoryData<Key>
+where
+    Key: Ord + Send + Sync + Debug + Hash + 'static,
+{
+    type ReadError = anyhow::Error;
+
+    async fn get(&self, key: (String, Vec<Key>)) -> Result<EntityUid, Self::ReadError> {
+        let (schema, segments) = key;
+        let guard = self.buckets.read().await;
+        let bucket = guard.get(&schema);
+        match bucket {
+            Some(trie_data) => trie_data.get(segments).await,
+            None => Err(anyhow!("Schema [{:?}] not found for key: [{:?}]", schema, segments)),
+        }
+    }
+}
+
+#[async_trait]
+impl<R, Key> ResourceUpdateHandler<R> for SchemaBoundedTrieRepositoryData<Key>
+where
+    Key: Ord + Send + Sync + Debug + Hash + Clone + 'static,
+    R: SchemaBoundResource + Resource + EntityCollectionResource<Key> + Send + Sync + Debug + 'static,
+{
+    async fn handle_update(&self, result: Result<R, watcher::Error>) -> () {
+        match &result {
+            Ok(document) => {
+                let mut guard = self.buckets.write().await;
+                let bucket = guard.entry(document.schema()).or_insert_with(TrieRepositoryData::new);
+                bucket.handle_update(result).await;
+            }
+            Err(e) => {
+                warn!("Error handling update: {:?}", e);
+            }
+        }
+    }
+}

--- a/src/services/repositories/lookup_trie/schema_bound_trie_repository.rs
+++ b/src/services/repositories/lookup_trie/schema_bound_trie_repository.rs
@@ -17,7 +17,7 @@ pub struct SchemaBoundedTrieRepositoryData<Key>
 where
     Key: Ord,
 {
-    pub buckets: RwLock<HashMap<String, TrieRepositoryData<Key>>>,
+    buckets: RwLock<HashMap<String, TrieRepositoryData<Key>>>,
 }
 
 impl<Key> SchemaBoundedTrieRepositoryData<Key>

--- a/src/services/repositories/policy_repository.rs
+++ b/src/services/repositories/policy_repository.rs
@@ -9,7 +9,7 @@ use boxer_core::services::base::upsert_repository::ReadOnlyRepository;
 use cedar_policy::PolicySet;
 
 pub trait PolicyReadOnlyRepositoryInterface:
-    ReadOnlyRepository<(), PolicySet, ReadError = anyhow::Error> + ResourceUpdateHandler<PolicyDocument>
+    ReadOnlyRepository<String, PolicySet, ReadError = anyhow::Error> + ResourceUpdateHandler<PolicyDocument>
 {
 }
 

--- a/src/services/repositories/policy_repository/policy_document.rs
+++ b/src/services/repositories/policy_repository/policy_document.rs
@@ -1,5 +1,4 @@
-use crate::http::controllers::action_set::models::SchemaBoundActionSetRegistration;
-use crate::http::controllers::policy_set::models::{PolicySetRegistration, SchemaBoundPolicySetRegistration};
+use crate::http::controllers::policy_set::models::SchemaBoundPolicySetRegistration;
 use boxer_core::services::backends::kubernetes::kubernetes_resource_manager::UpdateLabels;
 use boxer_core::services::backends::kubernetes::repositories::SoftDeleteResource;
 use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;

--- a/src/services/repositories/policy_repository/policy_document.rs
+++ b/src/services/repositories/policy_repository/policy_document.rs
@@ -1,4 +1,5 @@
-use crate::http::controllers::policy_set::models::PolicySetRegistration;
+use crate::http::controllers::action_set::models::SchemaBoundActionSetRegistration;
+use crate::http::controllers::policy_set::models::{PolicySetRegistration, SchemaBoundPolicySetRegistration};
 use boxer_core::services::backends::kubernetes::kubernetes_resource_manager::UpdateLabels;
 use boxer_core::services::backends::kubernetes::repositories::SoftDeleteResource;
 use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
@@ -19,6 +20,7 @@ use std::collections::BTreeMap;
 pub struct PolicyDocumentSpec {
     pub active: bool,
     pub policies: String,
+    pub schema: String,
 }
 
 impl Default for PolicyDocument {
@@ -32,23 +34,28 @@ impl Default for PolicyDocument {
             spec: PolicyDocumentSpec {
                 active: true,
                 policies: String::new(),
+                schema: Default::default(),
             },
         }
     }
 }
 
-impl From<PolicySetRegistration> for PolicyDocumentSpec {
-    fn from(value: PolicySetRegistration) -> Self {
+impl From<SchemaBoundPolicySetRegistration> for PolicyDocumentSpec {
+    fn from(value: SchemaBoundPolicySetRegistration) -> Self {
         PolicyDocumentSpec {
             active: true,
             policies: value.policy.to_string(),
+            schema: value.schema.to_string(),
         }
     }
 }
 
-impl Into<PolicySetRegistration> for PolicyDocumentSpec {
-    fn into(self) -> PolicySetRegistration {
-        PolicySetRegistration { policy: self.policies }
+impl Into<SchemaBoundPolicySetRegistration> for PolicyDocumentSpec {
+    fn into(self) -> SchemaBoundPolicySetRegistration {
+        SchemaBoundPolicySetRegistration {
+            policy: self.policies,
+            schema: self.schema,
+        }
     }
 }
 

--- a/src/services/repositories/policy_repository/read_write.rs
+++ b/src/services/repositories/policy_repository/read_write.rs
@@ -5,11 +5,11 @@ use boxer_core::services::backends::kubernetes::repositories::KubernetesReposito
 use boxer_core::services::base::upsert_repository::UpsertRepositoryWithDelete;
 
 pub type PolicyDataRepository = dyn UpsertRepositoryWithDelete<
-    String,
+    (String, String),
     PolicySetRegistration,
     DeleteError = Status,
     Error = Status,
     ReadError = Status,
 >;
 
-impl UpsertRepositoryWithDelete<String, PolicySetRegistration> for KubernetesRepository<PolicyDocument> {}
+impl UpsertRepositoryWithDelete<(String, String), PolicySetRegistration> for KubernetesRepository<PolicyDocument> {}

--- a/src/services/repositories/policy_repository/read_write.rs
+++ b/src/services/repositories/policy_repository/read_write.rs
@@ -1,4 +1,4 @@
-use crate::http::controllers::policy_set::models::PolicySetRegistration;
+use crate::http::controllers::policy_set::models::SchemaBoundPolicySetRegistration;
 use crate::services::repositories::policy_repository::policy_document::PolicyDocument;
 use boxer_core::services::backends::kubernetes::kubernetes_resource_manager::status::Status;
 use boxer_core::services::backends::kubernetes::repositories::KubernetesRepository;
@@ -6,10 +6,13 @@ use boxer_core::services::base::upsert_repository::UpsertRepositoryWithDelete;
 
 pub type PolicyDataRepository = dyn UpsertRepositoryWithDelete<
     (String, String),
-    PolicySetRegistration,
+    SchemaBoundPolicySetRegistration,
     DeleteError = Status,
     Error = Status,
     ReadError = Status,
 >;
 
-impl UpsertRepositoryWithDelete<(String, String), PolicySetRegistration> for KubernetesRepository<PolicyDocument> {}
+impl UpsertRepositoryWithDelete<(String, String), SchemaBoundPolicySetRegistration>
+    for KubernetesRepository<PolicyDocument>
+{
+}

--- a/src/services/repositories/resource_repository.rs
+++ b/src/services/repositories/resource_repository.rs
@@ -5,19 +5,7 @@ pub mod read_write;
 #[cfg(test)]
 mod tests;
 
-use crate::services::repositories::lookup_trie::TrieRepositoryData;
+use crate::services::repositories::lookup_trie::schema_bound_trie_repository::SchemaBoundedTrieRepositoryData;
 use crate::services::repositories::models::path_segment::PathSegment;
-use crate::services::repositories::resource_repository::resource_discovery_document::ResourceDiscoveryDocument;
-use boxer_core::services::backends::kubernetes::kubernetes_resource_watcher::ResourceUpdateHandler;
-use boxer_core::services::base::upsert_repository::ReadOnlyRepository;
-use cedar_policy::EntityUid;
 
-pub trait ResourceReadOnlyRepositoryInterface:
-    ReadOnlyRepository<Vec<PathSegment>, EntityUid, ReadError = anyhow::Error>
-    + ResourceUpdateHandler<ResourceDiscoveryDocument>
-{
-}
-
-impl ResourceReadOnlyRepositoryInterface for TrieRepositoryData<PathSegment> {}
-
-pub type ResourceReadOnlyRepository = dyn ResourceReadOnlyRepositoryInterface;
+pub type ResourceReadOnlyRepository = SchemaBoundedTrieRepositoryData<PathSegment>;

--- a/src/services/repositories/resource_repository/read_write.rs
+++ b/src/services/repositories/resource_repository/read_write.rs
@@ -5,11 +5,14 @@ use boxer_core::services::backends::kubernetes::repositories::KubernetesReposito
 use boxer_core::services::base::upsert_repository::UpsertRepositoryWithDelete;
 
 pub type ResourceDiscoveryDocumentRepository = dyn UpsertRepositoryWithDelete<
-    String,
+    (String, String),
     ResourceSetRegistration,
     DeleteError = Status,
     Error = Status,
     ReadError = Status,
 >;
 
-impl UpsertRepositoryWithDelete<String, ResourceSetRegistration> for KubernetesRepository<ResourceDiscoveryDocument> {}
+impl UpsertRepositoryWithDelete<(String, String), ResourceSetRegistration>
+    for KubernetesRepository<ResourceDiscoveryDocument>
+{
+}

--- a/src/services/repositories/resource_repository/read_write.rs
+++ b/src/services/repositories/resource_repository/read_write.rs
@@ -1,4 +1,4 @@
-use crate::http::controllers::resource_set::models::ResourceSetRegistration;
+use crate::http::controllers::resource_set::models::SchemaBoundResourceSetRegistration;
 use crate::services::repositories::resource_repository::resource_discovery_document::ResourceDiscoveryDocument;
 use boxer_core::services::backends::kubernetes::kubernetes_resource_manager::status::Status;
 use boxer_core::services::backends::kubernetes::repositories::KubernetesRepository;
@@ -6,13 +6,13 @@ use boxer_core::services::base::upsert_repository::UpsertRepositoryWithDelete;
 
 pub type ResourceDiscoveryDocumentRepository = dyn UpsertRepositoryWithDelete<
     (String, String),
-    ResourceSetRegistration,
+    SchemaBoundResourceSetRegistration,
     DeleteError = Status,
     Error = Status,
     ReadError = Status,
 >;
 
-impl UpsertRepositoryWithDelete<(String, String), ResourceSetRegistration>
+impl UpsertRepositoryWithDelete<(String, String), SchemaBoundResourceSetRegistration>
     for KubernetesRepository<ResourceDiscoveryDocument>
 {
 }

--- a/src/services/repositories/resource_repository/tests.rs
+++ b/src/services/repositories/resource_repository/tests.rs
@@ -3,9 +3,11 @@ use crate::http::controllers::resource_set::models::{ResourceRouteRegistration, 
 use crate::models::request_context::RequestContext;
 use crate::services::repositories::lookup_trie::backend::ReadOnlyRepositoryBackend;
 use crate::services::repositories::resource_repository::read_write::ResourceDiscoveryDocumentRepository;
+use crate::services::repositories::resource_repository::resource_discovery_document::ResourceDiscoveryDocument;
 use boxer_core::services::backends::kubernetes::kubernetes_resource_manager::KubernetesResourceManagerConfig;
 use boxer_core::services::backends::kubernetes::kubernetes_resource_watcher::KubernetesResourceWatcher;
 use boxer_core::services::backends::kubernetes::repositories::KubernetesRepository;
+use boxer_core::services::base::upsert_repository::ReadOnlyRepository;
 use boxer_core::services::service_provider::ServiceProvider;
 use boxer_core::testing::api_extensions::WaitForResource;
 use boxer_core::testing::spin_lock_kubernetes_resource_manager_context::SpinLockKubernetesResourceManagerTestContext;
@@ -20,7 +22,7 @@ struct KubernetesResourceRepositoryTest {
     repository: Arc<ResourceDiscoveryDocumentRepository>,
     api: Api<ResourceDiscoveryDocument>,
     namespace: String,
-    lookup: ReadOnlyRepositoryBackend<TrieRepositoryData<PathSegment>, ResourceDiscoveryDocument>,
+    lookup: ReadOnlyRepositoryBackend<SchemaBoundedTrieRepositoryData<PathSegment>, ResourceDiscoveryDocument>,
 }
 
 impl AsyncTestContext for KubernetesResourceRepositoryTest {
@@ -34,7 +36,7 @@ impl AsyncTestContext for KubernetesResourceRepositoryTest {
             owner_mark,
             operation_timeout: operation_timeout.clone(),
         };
-        let lookup_trie = Arc::new(TrieRepositoryData::<PathSegment>::new());
+        let lookup_trie = Arc::new(SchemaBoundedTrieRepositoryData::<PathSegment>::new());
         let lookup = ReadOnlyRepositoryBackend::start(config, lookup_trie.clone())
             .await
             .unwrap();
@@ -66,7 +68,10 @@ async fn test_create_resource_discovery_document(ctx: &mut KubernetesResourceRep
     };
 
     ctx.repository
-        .upsert(("schema".to_string(), name.to_string()), registration)
+        .upsert(
+            ("schema".to_string(), name.to_string()),
+            registration.with_schema("schema".to_string()),
+        )
         .await
         .expect("Failed to upsert schema");
 
@@ -82,7 +87,7 @@ async fn test_create_resource_discovery_document(ctx: &mut KubernetesResourceRep
     );
     let key = request_context.try_into().unwrap();
 
-    let after = ctx.lookup.get().get(key).await;
+    let after = ctx.lookup.get().get(("schema".to_string(), key)).await;
 
     // Assert
     assert!(after.is_ok());

--- a/src/services/repositories/resource_repository/tests.rs
+++ b/src/services/repositories/resource_repository/tests.rs
@@ -71,8 +71,9 @@ async fn test_create_resource_discovery_document(ctx: &mut KubernetesResourceRep
         .expect("Failed to upsert schema");
 
     // Act
+    let key = format!("{}-{}", "schema", name);
     ctx.api
-        .wait_for_creation(name.to_string(), ctx.namespace.clone(), DEFAULT_TEST_TIMEOUT)
+        .wait_for_creation(key, ctx.namespace.clone(), DEFAULT_TEST_TIMEOUT)
         .await;
 
     let request_context = RequestContext::new(

--- a/src/services/repositories/resource_repository/tests.rs
+++ b/src/services/repositories/resource_repository/tests.rs
@@ -54,9 +54,9 @@ impl AsyncTestContext for KubernetesResourceRepositoryTest {
 
 #[test_context(KubernetesResourceRepositoryTest)]
 #[tokio::test]
-async fn test_create_schema(ctx: &mut KubernetesResourceRepositoryTest) {
+async fn test_create_resource_discovery_document(ctx: &mut KubernetesResourceRepositoryTest) {
     // Arrange
-    let name = "action-discovery-document";
+    let name = "resource-discovery-document";
     let registration = ResourceSetRegistration {
         hostname: "www.example.com".to_string(),
         routes: vec![ResourceRouteRegistration {
@@ -66,7 +66,7 @@ async fn test_create_schema(ctx: &mut KubernetesResourceRepositoryTest) {
     };
 
     ctx.repository
-        .upsert(name.to_string(), registration)
+        .upsert(("schema".to_string(), name.to_string()), registration)
         .await
         .expect("Failed to upsert schema");
 

--- a/src/services/schema_provider.rs
+++ b/src/services/schema_provider.rs
@@ -8,7 +8,6 @@ use std::sync::Arc;
 
 pub struct KubernetesSchemaProvider {
     schema_repository: Arc<SchemaRepository>,
-    schema_name: String,
 }
 
 #[async_trait]
@@ -16,7 +15,7 @@ impl SchemaProvider for KubernetesSchemaProvider {
     async fn get_schema(&self, boxer_claims: &BoxerClaims) -> Result<Schema> {
         let actions_schema = self
             .schema_repository
-            .get(self.schema_name.clone())
+            .get(boxer_claims.schema.clone())
             .await
             .map_err(Error::from)?;
         let principal_schema = SchemaFragment::from_json_str(&boxer_claims.schema)?;
@@ -25,10 +24,7 @@ impl SchemaProvider for KubernetesSchemaProvider {
 }
 
 impl KubernetesSchemaProvider {
-    pub fn new(schema_repository: Arc<SchemaRepository>, schema_name: String) -> Self {
-        KubernetesSchemaProvider {
-            schema_repository,
-            schema_name,
-        }
+    pub fn new(schema_repository: Arc<SchemaRepository>) -> Self {
+        KubernetesSchemaProvider { schema_repository }
     }
 }


### PR DESCRIPTION
Part of https://github.com/SneaksAndData/terraform-provider-boxer/issues/12

## Scope

Implemented:
- Added the `schema` parameter to the following resources, which are schema-bound:
    - ActionDiscoveryDocument
    - ResourceDiscoveryDocument
    - PolicySet


Additional changes:
- Bump `boxer-crd` version
- Bump `boxer-core` version

## Checklist

- [ ] GitHub issue exists for this change.
- [ ] Unit tests added and they pass.
- [ ] Line Coverage is at least 80%.
- [ ] Review requested on `latest` commit.