### PR TITLE
Fix false NOT_FOUND status in the resources set

### DIFF
--- a/settings.toml
+++ b/settings.toml
@@ -30,4 +30,6 @@ keys = """
     "public": "0123456789ABCDEF0123456789ABCDEF"
 }
 """
+audience = "boxer.sneaksanddata.com" # Expected audience for tokens
+issuer = "boxer.sneaksanddata.com" # Expected audience for tokens
 

--- a/src/http/controllers/v1/resource_set.rs
+++ b/src/http/controllers/v1/resource_set.rs
@@ -23,7 +23,7 @@ async fn post_resource_set(
     data: Data<Arc<ResourceDiscoveryDocumentRepository>>,
 ) -> Result<impl Responder> {
     let (schema, id) = id.into_inner();
-    data.upsert((id, schema.clone()), request.into_inner().with_schema(schema))
+    data.upsert((schema.clone(), id), request.into_inner().with_schema(schema))
         .await?;
     Ok(HttpResponse::Ok().finish())
 }


### PR DESCRIPTION
Fixes wrong order of the primary key components

## Checklist

- [ ] GitHub issue exists for this change.
- [ ] Unit tests added and they pass.
- [ ] Line Coverage is at least 80%.
- [ ] Review requested on `latest` commit.