### PR TITLE
Add ability to read Traefik headers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,4 +18,4 @@ Cargo.lock
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
-#.idea/
+.idea/

--- a/src/http/extractors/nginx/request_context.rs
+++ b/src/http/extractors/nginx/request_context.rs
@@ -30,12 +30,106 @@ fn extract_headers(req: &HttpRequest) -> anyhow::Result<(String, String)> {
 }
 
 fn extract_header(req: &HttpRequest, header_name: &'static str, fallback: &'static str) -> anyhow::Result<String> {
+    let ctx = format!("{0}|{1}", header_name, fallback);
     let header_value = req
         .headers()
         .get(header_name)
         .or_else(|| req.headers().get(fallback))
-        .ok_or(anyhow::Error::msg("Missing original URL header").context(header_name))?
+        .ok_or(anyhow::Error::msg("Missing original URL header").context(ctx))?
         .to_str()?
         .to_owned();
     Ok(header_value)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use actix_web::test::TestRequest;
+
+    fn make_req(headers: &[(&str, &str)]) -> HttpRequest {
+        let mut builder = TestRequest::get();
+        for (name, value) in headers {
+            builder = builder.insert_header((*name, *value));
+        }
+        builder.to_http_request()
+    }
+
+    // extract_header tests
+
+    #[test]
+    fn test_extract_header_primary() {
+        let req = make_req(&[(ORIGINAL_URL_NGINX_HEADER, "http://example.com/path")]);
+        let result = extract_header(&req, ORIGINAL_URL_NGINX_HEADER, ORIGINAL_URL_TRAEFIK_HEADER);
+        assert_eq!(result.unwrap(), "http://example.com/path");
+    }
+
+    #[test]
+    fn test_extract_header_fallback() {
+        let req = make_req(&[(ORIGINAL_URL_TRAEFIK_HEADER, "/traefik-path")]);
+        let result = extract_header(&req, ORIGINAL_URL_NGINX_HEADER, ORIGINAL_URL_TRAEFIK_HEADER);
+        assert_eq!(result.unwrap(), "/traefik-path");
+    }
+
+    #[test]
+    fn test_extract_header_primary_takes_precedence_over_fallback() {
+        let req = make_req(&[
+            (ORIGINAL_URL_NGINX_HEADER, "http://primary.com"),
+            (ORIGINAL_URL_TRAEFIK_HEADER, "http://fallback.com"),
+        ]);
+        let result = extract_header(&req, ORIGINAL_URL_NGINX_HEADER, ORIGINAL_URL_TRAEFIK_HEADER);
+        assert_eq!(result.unwrap(), "http://primary.com");
+    }
+
+    #[test]
+    fn test_extract_header_missing_returns_error() {
+        let req = make_req(&[]);
+        let result = extract_header(&req, ORIGINAL_URL_NGINX_HEADER, ORIGINAL_URL_TRAEFIK_HEADER);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains(ORIGINAL_URL_NGINX_HEADER));
+    }
+
+    // extract_headers tests
+
+    #[test]
+    fn test_extract_headers_nginx_headers() {
+        let req = make_req(&[
+            (ORIGINAL_URL_NGINX_HEADER, "http://example.com/api"),
+            (ORIGINAL_METHOD_NGINX_HEADER, "GET"),
+        ]);
+        let (url, method) = extract_headers(&req).unwrap();
+        assert_eq!(url, "http://example.com/api");
+        assert_eq!(method, "GET");
+    }
+
+    #[test]
+    fn test_extract_headers_traefik_headers() {
+        let req = make_req(&[
+            (ORIGINAL_URL_TRAEFIK_HEADER, "/forwarded-uri"),
+            (ORIGINAL_METHOD_TRAEFIK_HEADER, "POST"),
+        ]);
+        let (url, method) = extract_headers(&req).unwrap();
+        assert_eq!(url, "/forwarded-uri");
+        assert_eq!(method, "POST");
+    }
+
+    #[test]
+    fn test_extract_headers_missing_url_returns_error() {
+        let req = make_req(&[(ORIGINAL_METHOD_NGINX_HEADER, "GET")]);
+        let result = extract_headers(&req);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_extract_headers_missing_method_returns_error() {
+        let req = make_req(&[(ORIGINAL_URL_NGINX_HEADER, "http://example.com")]);
+        let result = extract_headers(&req);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_extract_headers_both_missing_returns_error() {
+        let req = make_req(&[]);
+        let result = extract_headers(&req);
+        assert!(result.is_err());
+    }
 }

--- a/src/http/extractors/nginx/request_context.rs
+++ b/src/http/extractors/nginx/request_context.rs
@@ -27,8 +27,8 @@ impl FromRequest for RequestContext {
 }
 
 fn extract_headers(req: &HttpRequest) -> anyhow::Result<(String, String)> {
-    let original_url = extract_header(req, ORIGINAL_URL_NGINX_HEADER, ORIGINAL_URL_TRAEFIK_HEADER)?;
-    let original_method = extract_url(req, ORIGINAL_METHOD_NGINX_HEADER)?;
+    let original_url = extract_url(req, ORIGINAL_URL_NGINX_HEADER)?;
+    let original_method = extract_header(req, ORIGINAL_METHOD_NGINX_HEADER, ORIGINAL_METHOD_TRAEFIK_HEADER)?;
     Ok((original_url, original_method))
 }
 

--- a/src/http/extractors/nginx/request_context.rs
+++ b/src/http/extractors/nginx/request_context.rs
@@ -5,9 +5,12 @@ use boxer_core::services::observability::open_telemetry::tracing::{start_trace, 
 use futures_util::future::{ready, Ready};
 
 const ORIGINAL_URL_NGINX_HEADER: &str = "X-Original-URL";
-const ORIGINAL_URL_TRAEFIK_HEADER: &str = "X-Forwarded-Uri";
 const ORIGINAL_METHOD_NGINX_HEADER: &str = "X-Original-Method";
+
 const ORIGINAL_METHOD_TRAEFIK_HEADER: &str = "X-Forwarded-Method";
+const ORIGINAL_PROTOCOL_TRAEFIK_HEADER: &str = "X-Forwarded-Proto";
+const ORIGINAL_HOST_TRAEFIK_HEADER: &str = "X-Forwarded-Host";
+const ORIGINAL_URL_TRAEFIK_HEADER: &str = "X-Forwarded-Uri";
 
 impl FromRequest for RequestContext {
     type Error = actix_web::Error;
@@ -34,13 +37,24 @@ fn extract_header(req: &HttpRequest, header_name: &'static str, fallback: &'stat
     let fallback_header = req.headers().get(fallback);
     let result = match header {
         Some(value) => Some(value.to_str()?.to_string()),
-        None => match fallback_header {
-            Some(value) => Some(value.to_str()?.to_string()),
+        None => match extract_traefik_headers(req) {
+            Some(value) => Some(value),
             None => None,
         },
     };
 
     Ok(result.ok_or_else(|| anyhow::anyhow!("Missing required header: {header_name} or {fallback} in request"))?)
+}
+
+fn extract_traefik_headers(req: &HttpRequest) -> Option<String> {
+    let headers = req.headers();
+
+    let proto = headers.get(ORIGINAL_PROTOCOL_TRAEFIK_HEADER)?.to_str().ok()?;
+    let host = headers.get(ORIGINAL_HOST_TRAEFIK_HEADER)?.to_str().ok()?;
+    let uri = headers.get(ORIGINAL_URL_TRAEFIK_HEADER)?.to_str().ok()?;
+
+    let uri = uri.trim_start_matches('/');
+    Some(format!("{proto}://{host}/{uri}"))
 }
 
 #[cfg(test)]

--- a/src/http/extractors/nginx/request_context.rs
+++ b/src/http/extractors/nginx/request_context.rs
@@ -28,7 +28,7 @@ impl FromRequest for RequestContext {
 
 fn extract_headers(req: &HttpRequest) -> anyhow::Result<(String, String)> {
     let original_url = extract_header(req, ORIGINAL_URL_NGINX_HEADER, ORIGINAL_URL_TRAEFIK_HEADER)?;
-    let original_method = extract_header(req, ORIGINAL_METHOD_NGINX_HEADER, ORIGINAL_METHOD_TRAEFIK_HEADER)?;
+    let original_method = extract_url(req, ORIGINAL_METHOD_NGINX_HEADER)?;
     Ok((original_url, original_method))
 }
 
@@ -37,13 +37,26 @@ fn extract_header(req: &HttpRequest, header_name: &'static str, fallback: &'stat
     let fallback_header = req.headers().get(fallback);
     let result = match header {
         Some(value) => Some(value.to_str()?.to_string()),
+        None => match fallback_header {
+            Some(value) => Some(value.to_str()?.to_string()),
+            None => None,
+        },
+    };
+
+    Ok(result.ok_or_else(|| anyhow::anyhow!("Missing required header: {header_name} or {fallback} in request"))?)
+}
+
+fn extract_url(req: &HttpRequest, header_name: &'static str) -> anyhow::Result<String> {
+    let header = req.headers().get(header_name);
+    let result = match header {
+        Some(value) => Some(value.to_str()?.to_string()),
         None => match extract_traefik_headers(req) {
             Some(value) => Some(value),
             None => None,
         },
     };
 
-    Ok(result.ok_or_else(|| anyhow::anyhow!("Missing required header: {header_name} or {fallback} in request"))?)
+    Ok(result.ok_or_else(|| anyhow::anyhow!("Missing required headers"))?)
 }
 
 fn extract_traefik_headers(req: &HttpRequest) -> Option<String> {

--- a/src/http/extractors/nginx/request_context.rs
+++ b/src/http/extractors/nginx/request_context.rs
@@ -4,8 +4,10 @@ use actix_web::{FromRequest, HttpRequest};
 use boxer_core::services::observability::open_telemetry::tracing::{start_trace, ErrorExt};
 use futures_util::future::{ready, Ready};
 
-const ORIGINAL_URL_HEADER: &str = "X-Original-URL";
-const ORIGINAL_METHOD_HEADER: &str = "X-Original-Method";
+const ORIGINAL_URL_NGINX_HEADER: &str = "X-Original-URL";
+const ORIGINAL_URL_TRAEFIK_HEADER: &str = "X-Forwarded-Uri";
+const ORIGINAL_METHOD_NGINX_HEADER: &str = "X-Original-Method";
+const ORIGINAL_METHOD_TRAEFIK_HEADER: &str = "X-Forwarded-Method";
 
 impl FromRequest for RequestContext {
     type Error = actix_web::Error;
@@ -22,15 +24,16 @@ impl FromRequest for RequestContext {
 }
 
 fn extract_headers(req: &HttpRequest) -> anyhow::Result<(String, String)> {
-    let original_url = extract_header(req, ORIGINAL_URL_HEADER)?;
-    let original_method = extract_header(req, ORIGINAL_METHOD_HEADER)?;
+    let original_url = extract_header(req, ORIGINAL_URL_NGINX_HEADER, ORIGINAL_URL_TRAEFIK_HEADER)?;
+    let original_method = extract_header(req, ORIGINAL_METHOD_NGINX_HEADER, ORIGINAL_METHOD_TRAEFIK_HEADER)?;
     Ok((original_url, original_method))
 }
 
-fn extract_header(req: &HttpRequest, header_name: &'static str) -> anyhow::Result<String> {
+fn extract_header(req: &HttpRequest, header_name: &'static str, fallback: &'static str) -> anyhow::Result<String> {
     let header_value = req
         .headers()
         .get(header_name)
+        .or_else(|| req.headers().get(fallback))
         .ok_or(anyhow::Error::msg("Missing original URL header").context(header_name))?
         .to_str()?
         .to_owned();

--- a/src/http/extractors/nginx/request_context.rs
+++ b/src/http/extractors/nginx/request_context.rs
@@ -30,15 +30,17 @@ fn extract_headers(req: &HttpRequest) -> anyhow::Result<(String, String)> {
 }
 
 fn extract_header(req: &HttpRequest, header_name: &'static str, fallback: &'static str) -> anyhow::Result<String> {
-    let ctx = format!("{0}|{1}", header_name, fallback);
-    let header_value = req
-        .headers()
-        .get(header_name)
-        .or_else(|| req.headers().get(fallback))
-        .ok_or(anyhow::Error::msg("Missing original URL header").context(ctx))?
-        .to_str()?
-        .to_owned();
-    Ok(header_value)
+    let header = req.headers().get(header_name);
+    let fallback_header = req.headers().get(fallback);
+    let result = match header {
+        Some(value) => Some(value.to_str()?.to_string()),
+        None => match fallback_header {
+            Some(value) => Some(value.to_str()?.to_string()),
+            None => None,
+        },
+    };
+
+    Ok(result.ok_or_else(|| anyhow::anyhow!("Missing required header: {header_name} or {fallback} in request"))?)
 }
 
 #[cfg(test)]

--- a/src/http/extractors/nginx/request_context.rs
+++ b/src/http/extractors/nginx/request_context.rs
@@ -131,17 +131,6 @@ mod tests {
     }
 
     #[test]
-    fn test_extract_headers_traefik_headers() {
-        let req = make_req(&[
-            (ORIGINAL_URL_TRAEFIK_HEADER, "/forwarded-uri"),
-            (ORIGINAL_METHOD_TRAEFIK_HEADER, "POST"),
-        ]);
-        let (url, method) = extract_headers(&req).unwrap();
-        assert_eq!(url, "/forwarded-uri");
-        assert_eq!(method, "POST");
-    }
-
-    #[test]
     fn test_extract_headers_missing_url_returns_error() {
         let req = make_req(&[(ORIGINAL_METHOD_NGINX_HEADER, "GET")]);
         let result = extract_headers(&req);


### PR DESCRIPTION
This is a part of migration from Nginx to Traefik.

Traefik is not fully compatible with nginx, especially in case of forward auth provider. This PR contains a temporary workaround that will help to support two set of headers. In the nex version of Boxer, this approach will be revisited.

## Checklist

- [ ] GitHub issue exists for this change.
- [ ] Unit tests added and they pass.
- [ ] Line Coverage is at least 80%.
- [ ] Review requested on `latest` commit.